### PR TITLE
Bms

### DIFF
--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -63,6 +63,9 @@ BATT_SMBUS::BATT_SMBUS(I2CSPIBusOption bus_option, const int bus, SMBus *interfa
 	if ((SMBUS_DEVICE_TYPE)batt_device_type == SMBUS_DEVICE_TYPE::BQ40Z80) {
 		_device_type = SMBUS_DEVICE_TYPE::BQ40Z80;
 
+	} else if ((SMBUS_DEVICE_TYPE)batt_device_type == SMBUS_DEVICE_TYPE::BQ78350) {
+		_device_type = SMBUS_DEVICE_TYPE::BQ78350;
+
 	} else {
 		//default
 		_device_type = SMBUS_DEVICE_TYPE::BQ40Z50;
@@ -261,6 +264,14 @@ int BATT_SMBUS::get_cell_voltages()
 		_cell_voltages[4] = ((float)((DAstatus3[1] << 8) | DAstatus3[0]) / 1000.0f);
 		_cell_voltages[5] = ((float)((DAstatus3[7] << 8) | DAstatus3[6]) / 1000.0f);
 		_cell_voltages[6] = ((float)((DAstatus3[13] << 8) | DAstatus3[12]) / 1000.0f);
+
+	} else if (_device_type == SMBUS_DEVICE_TYPE::BQ78350) {
+		int cell_1_addr = BATT_SMBUS_BQ40Z50_CELL_1_VOLTAGE;
+		for (int i=0; i < _cell_count; i++){
+			ret |= _interface->read_word(cell_1_addr - i, result);
+			// Convert millivolts to volts.
+			_cell_voltages[i] = ((float)result) / 1000.0f;
+		}
 
 	}
 

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -109,7 +109,7 @@ void BATT_SMBUS::RunImpl()
 
 	new_report.connected = true;
 
-	ret |= _interface->read_word(BATT_SMBUS_VOLTAGE, result);
+	ret |= _interface->read_word(BATT_SMBUS_VOLTAGE_REG, result);
 
 	ret |= get_cell_voltages();
 
@@ -122,13 +122,13 @@ void BATT_SMBUS::RunImpl()
 	new_report.voltage_filtered_v = new_report.voltage_v;
 
 	// Read current.
-	ret |= _interface->read_word(BATT_SMBUS_CURRENT, result);
+	ret |= _interface->read_word(BATT_SMBUS_CURRENT_REG, result);
 
 	new_report.current_a = (-1.0f * ((float)(*(int16_t *)&result)) / 1000.0f) * _c_mult;
 	new_report.current_filtered_a = new_report.current_a;
 
 	// Read average current.
-	ret |= _interface->read_word(BATT_SMBUS_AVERAGE_CURRENT, result);
+	ret |= _interface->read_word(BATT_SMBUS_AVERAGE_CURRENT_REG, result);
 
 	float average_current = (-1.0f * ((float)(*(int16_t *)&result)) / 1000.0f) * _c_mult;
 
@@ -139,31 +139,31 @@ void BATT_SMBUS::RunImpl()
 	set_undervoltage_protection(average_current);
 
 	// Read run time to empty (minutes).
-	ret |= _interface->read_word(BATT_SMBUS_RUN_TIME_TO_EMPTY, result);
+	ret |= _interface->read_word(BATT_SMBUS_RUN_TIME_TO_EMPTY_REG, result);
 	new_report.run_time_to_empty = result;
 
 	// Read average time to empty (minutes).
-	ret |= _interface->read_word(BATT_SMBUS_AVERAGE_TIME_TO_EMPTY, result);
+	ret |= _interface->read_word(BATT_SMBUS_AVERAGE_TIME_TO_EMPTY_REG, result);
 	new_report.average_time_to_empty = result;
 
 	// Read remaining capacity.
-	ret |= _interface->read_word(BATT_SMBUS_REMAINING_CAPACITY, result);
+	ret |= _interface->read_word(BATT_SMBUS_REMAINING_CAPACITY_REG, result);
 
 	// Calculate total discharged amount in mah.
 	new_report.discharged_mah = _batt_startup_capacity - (float)result * _c_mult;
 
 	// Read Relative SOC.
-	ret |= _interface->read_word(BATT_SMBUS_RELATIVE_SOC, result);
+	ret |= _interface->read_word(BATT_SMBUS_RELATIVE_SOC_REG, result);
 
 	// Normalize 0.0 to 1.0
 	new_report.remaining = (float)result / 100.0f;
 
 	// Read Max Error
-	ret |= _interface->read_word(BATT_SMBUS_MAX_ERROR, result);
+	ret |= _interface->read_word(BATT_SMBUS_MAX_ERROR_REG, result);
 	new_report.max_error = result;
 
 	// Read battery temperature and covert to Celsius.
-	ret |= _interface->read_word(BATT_SMBUS_TEMP, result);
+	ret |= _interface->read_word(BATT_SMBUS_TEMP_REG, result);
 	new_report.temperature = ((float)result / 10.0f) + CONSTANTS_ABSOLUTE_NULL_CELSIUS;
 
 	// Only publish if no errors.
@@ -220,19 +220,19 @@ int BATT_SMBUS::get_cell_voltages()
 	int ret = PX4_OK;
 
 	if (_device_type == SMBUS_DEVICE_TYPE::BQ40Z50) {
-		ret |= _interface->read_word(BATT_SMBUS_BQ40Z50_CELL_1_VOLTAGE, result);
+		ret |= _interface->read_word(BATT_SMBUS_BQ40Z50_CELL_1_VOLTAGE_REG, result);
 		// Convert millivolts to volts.
 		_cell_voltages[0] = ((float)result) / 1000.0f;
 
-		ret |= _interface->read_word(BATT_SMBUS_BQ40Z50_CELL_2_VOLTAGE, result);
+		ret |= _interface->read_word(BATT_SMBUS_BQ40Z50_CELL_2_VOLTAGE_REG, result);
 		// Convert millivolts to volts.
 		_cell_voltages[1] = ((float)result) / 1000.0f;
 
-		ret |= _interface->read_word(BATT_SMBUS_BQ40Z50_CELL_3_VOLTAGE, result);
+		ret |= _interface->read_word(BATT_SMBUS_BQ40Z50_CELL_3_VOLTAGE_REG, result);
 		// Convert millivolts to volts.
 		_cell_voltages[2] = ((float)result) / 1000.0f;
 
-		ret |= _interface->read_word(BATT_SMBUS_BQ40Z50_CELL_4_VOLTAGE, result);
+		ret |= _interface->read_word(BATT_SMBUS_BQ40Z50_CELL_4_VOLTAGE_REG, result);
 		// Convert millivolts to volts.
 		_cell_voltages[3] = ((float)result) / 1000.0f;
 		_cell_voltages[4] = 0;
@@ -268,7 +268,7 @@ int BATT_SMBUS::get_cell_voltages()
 		_cell_voltages[6] = ((float)((DAstatus3[13] << 8) | DAstatus3[12]) / 1000.0f);
 
 	} else if (_device_type == SMBUS_DEVICE_TYPE::BQ78350) {
-		int cell_1_addr = BATT_SMBUS_BQ78350_CELL_1_VOLTAGE_ADDR;
+		int cell_1_addr = BATT_SMBUS_BQ78350_CELL_1_VOLTAGE_REG;
 		for (int i=0; i < _cell_count; i++){
 			//Get each cell voltage, adresses decrementing from first cell per definition of BQ78350 adress space
 			if (PX4_OK != _interface->read_word(cell_1_addr - i, result)){
@@ -336,7 +336,7 @@ void BATT_SMBUS::set_undervoltage_protection(float average_current)
 //@NOTE: Currently unused, could be helpful for debugging a parameter set though.
 int BATT_SMBUS::dataflash_read(const uint16_t address, void *data, const unsigned length)
 {
-	uint8_t code = BATT_SMBUS_MANUFACTURER_BLOCK_ACCESS;
+	uint8_t code = BATT_SMBUS_MANUFACTURER_BLOCK_ACCESS_REG;
 
 	int ret = _interface->block_write(code, &address, 2, true);
 
@@ -351,7 +351,7 @@ int BATT_SMBUS::dataflash_read(const uint16_t address, void *data, const unsigne
 
 int BATT_SMBUS::dataflash_write(const uint16_t address, void *data, const unsigned length)
 {
-	uint8_t code = BATT_SMBUS_MANUFACTURER_BLOCK_ACCESS;
+	uint8_t code = BATT_SMBUS_MANUFACTURER_BLOCK_ACCESS_REG;
 
 	uint8_t tx_buf[MAC_DATA_BUFFER_SIZE + 2] = {};
 
@@ -384,27 +384,27 @@ int BATT_SMBUS::get_startup_info()
 	param_get(param_find("BAT_N_CELLS"), &cell_count_param);
 	_cell_count = math::min((uint8_t)cell_count_param, MAX_NUM_OF_CELLS);
 
-	ret |= _interface->block_read(BATT_SMBUS_MANUFACTURER_NAME, _manufacturer_name, BATT_SMBUS_MANUFACTURER_NAME_SIZE,
+	ret |= _interface->block_read(BATT_SMBUS_MANUFACTURER_NAME_REG, _manufacturer_name, BATT_SMBUS_MANUFACTURER_NAME_SIZE,
 				      true);
 	_manufacturer_name[sizeof(_manufacturer_name) - 1] = '\0';
 
 	uint16_t serial_num;
-	ret |= _interface->read_word(BATT_SMBUS_SERIAL_NUMBER, serial_num);
+	ret |= _interface->read_word(BATT_SMBUS_SERIAL_NUMBER_REG, serial_num);
 
 	uint16_t remaining_cap;
-	ret |= _interface->read_word(BATT_SMBUS_REMAINING_CAPACITY, remaining_cap);
+	ret |= _interface->read_word(BATT_SMBUS_REMAINING_CAPACITY_REG, remaining_cap);
 
 	uint16_t cycle_count;
-	ret |= _interface->read_word(BATT_SMBUS_CYCLE_COUNT, cycle_count);
+	ret |= _interface->read_word(BATT_SMBUS_CYCLE_COUNT_REG, cycle_count);
 
 	uint16_t full_cap;
-	ret |= _interface->read_word(BATT_SMBUS_FULL_CHARGE_CAPACITY, full_cap);
+	ret |= _interface->read_word(BATT_SMBUS_FULL_CHARGE_CAPACITY_REG, full_cap);
 
 	uint16_t manufacture_date;
-	ret |= _interface->read_word(BATT_SMBUS_MANUFACTURE_DATE, manufacture_date);
+	ret |= _interface->read_word(BATT_SMBUS_MANUFACTURE_DATE_REG, manufacture_date);
 
 	uint16_t state_of_health;
-	ret |= _interface->read_word(BATT_SMBUS_STATE_OF_HEALTH, state_of_health);
+	ret |= _interface->read_word(BATT_SMBUS_STATE_OF_HEALTH_REG, state_of_health);
 
 	if (!ret) {
 		_serial_number = serial_num;
@@ -435,7 +435,7 @@ int BATT_SMBUS::get_startup_info()
 
 int BATT_SMBUS::manufacturer_read(const uint16_t cmd_code, void *data, const unsigned length)
 {
-	uint8_t code = BATT_SMBUS_MANUFACTURER_BLOCK_ACCESS;
+	uint8_t code = BATT_SMBUS_MANUFACTURER_BLOCK_ACCESS_REG;
 
 	uint8_t address[2] = {};
 	address[0] = ((uint8_t *)&cmd_code)[0];
@@ -455,7 +455,7 @@ int BATT_SMBUS::manufacturer_read(const uint16_t cmd_code, void *data, const uns
 
 int BATT_SMBUS::manufacturer_write(const uint16_t cmd_code, void *data, const unsigned length)
 {
-	uint8_t code = BATT_SMBUS_MANUFACTURER_BLOCK_ACCESS;
+	uint8_t code = BATT_SMBUS_MANUFACTURER_BLOCK_ACCESS_REG;
 
 	uint8_t tx_buf[MAC_DATA_BUFFER_SIZE + 2] = {};
 	tx_buf[0] = cmd_code & 0xff;
@@ -475,9 +475,9 @@ int BATT_SMBUS::unseal()
 	// See bq40z50 technical reference.
 	uint16_t keys[2] = {0x0414, 0x3672};
 
-	int ret = _interface->write_word(BATT_SMBUS_MANUFACTURER_ACCESS, keys[0]);
+	int ret = _interface->write_word(BATT_SMBUS_MANUFACTURER_ACCESS_REG, keys[0]);
 
-	ret |= _interface->write_word(BATT_SMBUS_MANUFACTURER_ACCESS, keys[1]);
+	ret |= _interface->write_word(BATT_SMBUS_MANUFACTURER_ACCESS_REG, keys[1]);
 
 	return ret;
 }

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -169,8 +169,9 @@ void BATT_SMBUS::RunImpl()
 	// Only publish if no errors.
 	if (ret == PX4_OK) {
 
-		if( _failed_sends >= BATT_SMBUS_CON_LOST_MSGS_THRESHOLD){
+		if( _conn_lost){
 			PX4_INFO("Connection to BMS regained");
+			_conn_lost = false;
 		}
 		_failed_sends = 0;
 
@@ -204,9 +205,10 @@ void BATT_SMBUS::RunImpl()
 		orb_publish_auto(ORB_ID(battery_status), &_batt_topic, &new_report, &instance);
 
 		_last_report = new_report;
-	} else {
+	} else if(!_conn_lost) {
 		if( _failed_sends >= BATT_SMBUS_CON_LOST_MSGS_THRESHOLD){
 			PX4_ERR("Connection to BMS lost");
+			_conn_lost = true;
 		} else {
 			_failed_sends++;
 		}

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -405,14 +405,16 @@ int BATT_SMBUS::get_startup_info()
 
 	uint16_t state_of_health;
 	ret |= _interface->read_word(BATT_SMBUS_STATE_OF_HEALTH_REG, state_of_health);
-
 	if (!ret) {
+		PX4_INFO("Got startup info");
 		_serial_number = serial_num;
 		_batt_startup_capacity = (uint16_t)((float)remaining_cap * _c_mult);
 		_cycle_count = cycle_count;
 		_batt_capacity = (uint16_t)((float)full_cap * _c_mult);
 		_manufacture_date = manufacture_date;
 		_state_of_health = state_of_health;
+	} else{
+		PX4_WARN("Could not get startup info");
 	}
 
 	if (lifetime_data_flush() == PX4_OK) {

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -35,7 +35,7 @@
  * @file batt_smbus.h
  *
  * Header for a battery monitor connected via SMBus (I2C).
- * Designed for BQ40Z50-R1/R2 and BQ40Z80
+ * Designed for BQ40Z50-R1/R2, BQ40Z80 and BQ78350
  *
  * @author Jacob Dahl <dahl.jakejacob@gmail.com>
  * @author Alex Klimaj <alexklimaj@gmail.com>
@@ -268,6 +268,7 @@ int BATT_SMBUS::get_cell_voltages()
 	} else if (_device_type == SMBUS_DEVICE_TYPE::BQ78350) {
 		int cell_1_addr = BATT_SMBUS_BQ40Z50_CELL_1_VOLTAGE;
 		for (int i=0; i < _cell_count; i++){
+			//Get each cell voltage, adresses decrementing from first cell
 			ret |= _interface->read_word(cell_1_addr - i, result);
 			// Convert millivolts to volts.
 			_cell_voltages[i] = ((float)result) / 1000.0f;

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -171,6 +171,7 @@ void BATT_SMBUS::RunImpl()
 
 		if( _conn_lost){
 			PX4_INFO("Connection to BMS regained");
+			mavlink_log_info(&_mavlink_log_pub, "Battery telemetry regained.")
 			_conn_lost = false;
 		}
 		_failed_sends = 0;
@@ -208,6 +209,7 @@ void BATT_SMBUS::RunImpl()
 	} else if(!_conn_lost) {
 		if( _failed_sends >= BATT_SMBUS_CON_LOST_MSGS_THRESHOLD){
 			PX4_ERR("Connection to BMS lost");
+			mavlink_log_critical(&_mavlink_log_pub, "Battery telemetry lost.");
 			_conn_lost = true;
 		} else {
 			_failed_sends++;

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -168,6 +168,12 @@ void BATT_SMBUS::RunImpl()
 
 	// Only publish if no errors.
 	if (ret == PX4_OK) {
+
+		if( _failed_sends >= BATT_SMBUS_CON_LOST_MSGS_THRESHOLD){
+			PX4_INFO("Connection to BMS regained");
+		}
+		_failed_sends = 0;
+
 		new_report.capacity = _batt_capacity;
 		new_report.cycle_count = _cycle_count;
 		new_report.serial_number = _serial_number;
@@ -199,7 +205,12 @@ void BATT_SMBUS::RunImpl()
 
 		_last_report = new_report;
 	} else {
-		PX4_WARN("Error reading battery status");
+		if( _failed_sends >= BATT_SMBUS_CON_LOST_MSGS_THRESHOLD){
+			PX4_ERR("Connection to BMS lost");
+		} else {
+			_failed_sends++;
+		}
+
 	}
 }
 

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -250,6 +250,9 @@ private:
 	/** @param _failed_sends Number of times in a row the batter_status msg could not be sent. */
 	uint8_t _failed_sends{0};
 
+	/** @param _conn_lost If connection is considered lost, battery_status msgs not sent until regained. */
+	bool _conn_lost{false};
+
 	/** @param _batt_topic uORB battery topic. */
 	orb_advert_t _batt_topic{nullptr};
 

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -60,6 +60,8 @@ using namespace time_literals;
 
 #define BATT_SMBUS_MEASUREMENT_INTERVAL_US              100_ms         ///< time in microseconds, measure at 10Hz
 
+#define BATT_SMBUS_CON_LOST_MSGS_THRESHOLD		5	       ///< Number of lost msgs before connection considered lost
+
 #define MAC_DATA_BUFFER_SIZE                            32
 
 #define BATT_CELL_VOLTAGE_THRESHOLD_RTL                 0.5f            ///< Threshold in volts to RTL if cells are imbalanced
@@ -244,6 +246,9 @@ private:
 
 	/** @param _last_report Last published report, used for test(). */
 	battery_status_s _last_report{};
+
+	/** @param _failed_sends Number of times in a row the batter_status msg could not be sent. */
+	uint8_t _failed_sends{0};
 
 	/** @param _batt_topic uORB battery topic. */
 	orb_advert_t _batt_topic{nullptr};

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -35,7 +35,7 @@
  * @file batt_smbus.h
  *
  * Header for a battery monitor connected via SMBus (I2C).
- * Designed for BQ40Z50-R1/R2 or BQ40Z80
+ * Designed for BQ40Z50-R1/R2, BQ40Z80 or BQ78350
  *
  * @author Jacob Dahl <dahl.jakejacob@gmail.com>
  * @author Alex Klimaj <alexklimaj@gmail.com>
@@ -122,6 +122,7 @@ enum class SMBUS_DEVICE_TYPE {
 	UNDEFINED     = 0,
 	BQ40Z50       = 1,
 	BQ40Z80       = 2,
+	BQ78350       = 3,
 };
 
 class BATT_SMBUS : public I2CSPIDriver<BATT_SMBUS>
@@ -229,7 +230,7 @@ private:
 
 	perf_counter_t _cycle{perf_alloc(PC_ELAPSED, "batt_smbus_cycle")};
 
-	static const uint8_t MAX_NUM_OF_CELLS = 7;
+	static const uint8_t MAX_NUM_OF_CELLS = 16;
 	float _cell_voltages[MAX_NUM_OF_CELLS] {};
 
 	float _max_cell_voltage_delta{0};

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -35,7 +35,7 @@
  * @file batt_smbus.h
  *
  * Header for a battery monitor connected via SMBus (I2C).
- * Designed for BQ40Z50-R1/R2, BQ40Z80 or BQ78350
+ * Designed for BQ40Z50-R1/R2, BQ40Z80 and BQ78350
  *
  * @author Jacob Dahl <dahl.jakejacob@gmail.com>
  * @author Alex Klimaj <alexklimaj@gmail.com>

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -70,42 +70,42 @@ using namespace time_literals;
 
 #define BATT_SMBUS_ADDR                                 0x0B            ///< Default 7 bit address I2C address. 8 bit = 0x16
 
-#define BATT_SMBUS_TEMP                                 0x08            ///< temperature register
-#define BATT_SMBUS_VOLTAGE                              0x09            ///< voltage register
-#define BATT_SMBUS_CURRENT                              0x0A            ///< current register
-#define BATT_SMBUS_AVERAGE_CURRENT                      0x0B            ///< average current register
-#define BATT_SMBUS_MAX_ERROR                            0x0C            ///< max error
-#define BATT_SMBUS_RELATIVE_SOC                         0x0D            ///< Relative State Of Charge
-#define BATT_SMBUS_ABSOLUTE_SOC                         0x0E            ///< Absolute State of charge
-#define BATT_SMBUS_REMAINING_CAPACITY                   0x0F            ///< predicted remaining battery capacity as a percentage
-#define BATT_SMBUS_FULL_CHARGE_CAPACITY                 0x10            ///< capacity when fully charged
-#define BATT_SMBUS_RUN_TIME_TO_EMPTY                    0x11            ///< predicted remaining battery capacity based on the present rate of discharge in min
-#define BATT_SMBUS_AVERAGE_TIME_TO_EMPTY                0x12            ///< predicted remaining battery capacity based on the present rate of discharge in min
-#define BATT_SMBUS_CYCLE_COUNT                          0x17            ///< number of cycles the battery has experienced
-#define BATT_SMBUS_DESIGN_CAPACITY                      0x18            ///< design capacity register
-#define BATT_SMBUS_DESIGN_VOLTAGE                       0x19            ///< design voltage register
-#define BATT_SMBUS_MANUFACTURER_NAME                    0x20            ///< manufacturer name
+#define BATT_SMBUS_TEMP_REG                             0x08            ///< temperature register
+#define BATT_SMBUS_VOLTAGE_REG                          0x09            ///< voltage register
+#define BATT_SMBUS_CURRENT_REG                          0x0A            ///< current register
+#define BATT_SMBUS_AVERAGE_CURRENT_REG                  0x0B            ///< average current register
+#define BATT_SMBUS_MAX_ERROR_REG                        0x0C            ///< max error
+#define BATT_SMBUS_RELATIVE_SOC_REG                     0x0D            ///< Relative State Of Charge
+#define BATT_SMBUS_ABSOLUTE_SOC_REG                     0x0E            ///< Absolute State of charge
+#define BATT_SMBUS_REMAINING_CAPACITY_REG               0x0F            ///< predicted remaining battery capacity as a percentage
+#define BATT_SMBUS_FULL_CHARGE_CAPACITY_REG             0x10            ///< capacity when fully charged
+#define BATT_SMBUS_RUN_TIME_TO_EMPTY_REG                0x11            ///< predicted remaining battery capacity based on the present rate of discharge in min
+#define BATT_SMBUS_AVERAGE_TIME_TO_EMPTY_REG            0x12            ///< predicted remaining battery capacity based on the present rate of discharge in min
+#define BATT_SMBUS_CYCLE_COUNT_REG                      0x17            ///< number of cycles the battery has experienced
+#define BATT_SMBUS_DESIGN_CAPACITY_REG                  0x18            ///< design capacity register
+#define BATT_SMBUS_DESIGN_VOLTAGE_REG                   0x19            ///< design voltage register
+#define BATT_SMBUS_MANUFACTURER_NAME_REG                0x20            ///< manufacturer name
 #define BATT_SMBUS_MANUFACTURER_NAME_SIZE               21              ///< manufacturer name data size
-#define BATT_SMBUS_MANUFACTURE_DATE                     0x1B            ///< manufacture date register
-#define BATT_SMBUS_SERIAL_NUMBER                        0x1C            ///< serial number register
+#define BATT_SMBUS_MANUFACTURE_DATE_REG                 0x1B            ///< manufacture date register
+#define BATT_SMBUS_SERIAL_NUMBER_REG                    0x1C            ///< serial number register
 
-#define BATT_SMBUS_BQ40Z50_CELL_4_VOLTAGE               0x3C
-#define BATT_SMBUS_BQ40Z50_CELL_3_VOLTAGE               0x3D
-#define BATT_SMBUS_BQ40Z50_CELL_2_VOLTAGE               0x3E
-#define BATT_SMBUS_BQ40Z50_CELL_1_VOLTAGE               0x3F
+#define BATT_SMBUS_BQ40Z50_CELL_4_VOLTAGE_REG           0x3C
+#define BATT_SMBUS_BQ40Z50_CELL_3_VOLTAGE_REG           0x3D
+#define BATT_SMBUS_BQ40Z50_CELL_2_VOLTAGE_REG           0x3E
+#define BATT_SMBUS_BQ40Z50_CELL_1_VOLTAGE_REG           0x3F
 
-#define BATT_SMBUS_BQ40Z80_CELL_7_VOLTAGE               0x3C
-#define BATT_SMBUS_BQ40Z80_CELL_6_VOLTAGE               0x3D
-#define BATT_SMBUS_BQ40Z80_CELL_5_VOLTAGE               0x3E
-#define BATT_SMBUS_BQ40Z80_CELL_4_VOLTAGE               0x3F
+#define BATT_SMBUS_BQ40Z80_CELL_7_VOLTAGE_REG           0x3C
+#define BATT_SMBUS_BQ40Z80_CELL_6_VOLTAGE_REG           0x3D
+#define BATT_SMBUS_BQ40Z80_CELL_5_VOLTAGE_REG           0x3E
+#define BATT_SMBUS_BQ40Z80_CELL_4_VOLTAGE_REG           0x3F
 
-#define BATT_SMBUS_BQ78350_CELL_1_VOLTAGE_ADDR          0x3F
+#define BATT_SMBUS_BQ78350_CELL_1_VOLTAGE_REG           0x3F
 
-#define BATT_SMBUS_STATE_OF_HEALTH                      0x4F            ///< State of Health. The SOH information of the battery in percentage of Design Capacity
+#define BATT_SMBUS_STATE_OF_HEALTH_REG                  0x4F            ///< State of Health. The SOH information of the battery in percentage of Design Capacity
 
-#define BATT_SMBUS_MANUFACTURER_ACCESS                  0x00
-#define BATT_SMBUS_MANUFACTURER_DATA                    0x23
-#define BATT_SMBUS_MANUFACTURER_BLOCK_ACCESS            0x44
+#define BATT_SMBUS_MANUFACTURER_ACCESS_REG              0x00
+#define BATT_SMBUS_MANUFACTURER_DATA_REG                0x23
+#define BATT_SMBUS_MANUFACTURER_BLOCK_ACCESS_REG        0x44
 
 #define BATT_SMBUS_SECURITY_KEYS                        0x0035
 

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -52,7 +52,10 @@
 #include <px4_platform_common/param.h>
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/i2c_spi_buses.h>
+#include <systemlib/mavlink_log.h>
+
 #include <uORB/topics/battery_status.h>
+#include <uORB/topics/mavlink_log.h>
 
 #include <board_config.h>
 
@@ -60,7 +63,7 @@ using namespace time_literals;
 
 #define BATT_SMBUS_MEASUREMENT_INTERVAL_US              100_ms         ///< time in microseconds, measure at 10Hz
 
-#define BATT_SMBUS_CON_LOST_MSGS_THRESHOLD		5	       ///< Number of lost msgs before connection considered lost
+#define BATT_SMBUS_CON_LOST_MSGS_THRESHOLD		        10	           ///< Number of lost msgs before connection considered lost
 
 #define MAC_DATA_BUFFER_SIZE                            32
 
@@ -255,6 +258,8 @@ private:
 
 	/** @param _batt_topic uORB battery topic. */
 	orb_advert_t _batt_topic{nullptr};
+	/** @param _mavlink_log_pub mavlink log topic*/
+	orb_advert_t _mavlink_log_pub {nullptr};
 
 	/** @param _cell_count Number of series cell. */
 	uint8_t _cell_count{0};

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -99,6 +99,8 @@ using namespace time_literals;
 #define BATT_SMBUS_BQ40Z80_CELL_5_VOLTAGE               0x3E
 #define BATT_SMBUS_BQ40Z80_CELL_4_VOLTAGE               0x3F
 
+#define BATT_SMBUS_BQ78350_CELL_1_VOLTAGE_ADDR          0x3F
+
 #define BATT_SMBUS_STATE_OF_HEALTH                      0x4F            ///< State of Health. The SOH information of the battery in percentage of Design Capacity
 
 #define BATT_SMBUS_MANUFACTURER_ACCESS                  0x00

--- a/src/drivers/batt_smbus/parameters.c
+++ b/src/drivers/batt_smbus/parameters.c
@@ -56,10 +56,10 @@ PARAM_DEFINE_FLOAT(BAT_C_MULT, 1.0f);
  * @reboot_required true
  * @min 0
  * @max 3
- * @group Sensors
- * @value 0 AutoDetect
+ * @value 0 Auto(BQ40Z50)
  * @value 1 BQ40Z50 based
  * @value 2 BQ40Z80 based
  * @value 3 BQ78350 based
+ * @group Sensors
  */
-PARAM_DEFINE_INT32(BAT_SMBUS_MODEL, 0);
+PARAM_DEFINE_INT32(BAT_SMBUS_MODEL, 3);

--- a/src/drivers/batt_smbus/parameters.c
+++ b/src/drivers/batt_smbus/parameters.c
@@ -55,10 +55,11 @@ PARAM_DEFINE_FLOAT(BAT_C_MULT, 1.0f);
  *
  * @reboot_required true
  * @min 0
- * @max 2
+ * @max 3
  * @group Sensors
  * @value 0 AutoDetect
  * @value 1 BQ40Z50 based
  * @value 2 BQ40Z80 based
+ * @value 3 BQ78350 based
  */
 PARAM_DEFINE_INT32(BAT_SMBUS_MODEL, 0);


### PR DESCRIPTION
Add support for BQ78350 in the batt_smbus driver. Correct readings have been verified at different currents drawn from battery while logging. 
