### PR TITLE
Added winch support

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1459,6 +1459,7 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 			}
 			break;
 
+		case MAV_CMD_DO_WINCH:
 		case MAV_CMD_DO_CHANGE_SPEED:
 		case MAV_CMD_DO_SET_HOME:
 		case MAV_CMD_DO_SET_SERVO:
@@ -1556,6 +1557,7 @@ MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *
 			mavlink_mission_item->param2 = mission_item->do_jump_repeat_count;
 			break;
 
+		case NAV_CMD_DO_WINCH:
 		case NAV_CMD_DO_CHANGE_SPEED:
 		case NAV_CMD_DO_SET_HOME:
 		case NAV_CMD_DO_SET_SERVO:

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -86,6 +86,7 @@ MissionBlock::is_mission_item_reached()
 	case NAV_CMD_LOITER_UNLIMITED:
 		return false;
 
+	case NAV_CMD_DO_WINCH:
 	case NAV_CMD_DO_LAND_START:
 	case NAV_CMD_DO_TRIGGER_CONTROL:
 	case NAV_CMD_DO_DIGICAM_CONTROL:

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -224,7 +224,8 @@ MissionFeasibilityChecker::checkMissionItemValidity(const mission_s &mission)
 		}
 
 		// check if we find unsupported items and reject mission if so
-		if (missionitem.nav_cmd != NAV_CMD_IDLE &&
+		if (missionitem.nav_cmd != NAV_CMD_DO_WINCH &&
+		    missionitem.nav_cmd != NAV_CMD_IDLE &&
 		    missionitem.nav_cmd != NAV_CMD_WAYPOINT &&
 		    missionitem.nav_cmd != NAV_CMD_LOITER_UNLIMITED &&
 		    missionitem.nav_cmd != NAV_CMD_LOITER_TIME_LIMIT &&

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -101,6 +101,7 @@ enum NAV_CMD {
 	NAV_CMD_FENCE_CIRCLE_INCLUSION = 5003,
 	NAV_CMD_FENCE_CIRCLE_EXCLUSION = 5004,
 	NAV_CMD_CONDITION_GATE = 4501,
+	NAV_CMD_DO_WINCH = 42600,
 	NAV_CMD_INVALID = UINT16_MAX /* ensure that casting a large number results in a specific error */
 };
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1377,7 +1377,9 @@ Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)
 	case NAV_CMD_VIDEO_STOP_CAPTURE:
 		vcmd->target_component = 100; // MAV_COMP_ID_CAMERA
 		break;
-
+	case NAV_CMD_DO_WINCH:
+		vcmd->target_component = 42; // WINCH
+		break;
 	default:
 		vcmd->target_component = _vstatus.component_id;
 		break;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1378,7 +1378,9 @@ Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)
 		vcmd->target_component = 100; // MAV_COMP_ID_CAMERA
 		break;
 	case NAV_CMD_DO_WINCH:
-		vcmd->target_component = 42; // WINCH
+		// MAV_COMP_ID_USER18(42) is the chosen component for winches
+		// since no winch defaults exist yet in the MAVLink standard.
+		vcmd->target_component = 42;
 		break;
 	default:
 		vcmd->target_component = _vstatus.component_id;


### PR DESCRIPTION
**Describe problem solved by this pull request**
When designing mission items, all commands in said item are sent to the vehicle (except camera commands). We want the winch commands to be sent to a different component.

**Describe your solution**
MAV_CMD_DO_WINCH is added to PX4's list of supported commands. In the case of an incoming winch command, it is sent to the winch component (42) just like for camera actions.

**Describe possible alternatives**
Modifying the existing camera trigger functionality to perform winching actions.

**Test data / coverage**
Verified that commands are forwarded when mission item is reached in simulator. 

**Additional context**
See [this QGC branch](https://github.com/aviant-tech/qgroundcontrol/tree/aviant-winch-support/V4.2).
