### PR TITLE
Disable time stretch while landing in auto

### DIFF
--- a/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -462,6 +462,14 @@ void FlightTaskAutoLineSmoothVel::_generateTrajectory()
 		time_stretch = 1.f;
 	}
 
+	// Don't stretch time while landing
+	// This is to prevent scenarios where the drone is unable to land
+	// due to strong winds that blows the drone away from its setpoint
+	// TODO Create a parameter to enable/disable this feature
+	if (_type == WaypointType::land) {
+		time_stretch = 1.f;
+	}
+
 	Vector3f jerk_sp_smooth;
 	Vector3f accel_sp_smooth;
 	Vector3f vel_sp_smooth;

--- a/src/modules/flight_mode_manager/tasks/AutoMapper/FlightTaskAutoMapper.cpp
+++ b/src/modules/flight_mode_manager/tasks/AutoMapper/FlightTaskAutoMapper.cpp
@@ -77,6 +77,16 @@ bool FlightTaskAutoMapper::update()
 		break;
 
 	case WaypointType::land:
+	        if (_type_previous != _type) {
+			// Reset the trajectory current position when initializing landing.
+			// This is important when time stretching is disabled for landing trajectory,
+			// when the drone is blown away from its current setpoint by strong winds.
+			// This reduces that chance that when the drone descends to lower altitudes
+			// with potentially less wind, and moves towards its previous trajectory setpoint.
+			// TODO Should be set by a common parameter as disable time stretch for landing.
+			// TODO evaluate if needed to reset position again during landing if drift is too high
+			_ekfResetHandlerPositionXY();
+		}
 		_prepareLandSetpoints();
 		break;
 


### PR DESCRIPTION
If wind is too strong for the drone to hold position, time stretch can prevent the drone from ever landing. Also reset trajectory setpoint XY position when starting landing.