### PR TITLE
Make predictive battery failsafe optional

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3693,28 +3693,30 @@ void Commander::battery_status_check()
 
 	battery_level /= num_connected_batteries;
 
-	_rtl_flight_time_sub.update();
-	float battery_usage_to_home = 0;
+	if (_param_com_pred_bat_fs.get() == 1) {
+		_rtl_flight_time_sub.update();
+		float battery_usage_to_home = 0;
 
-	if (hrt_absolute_time() - _rtl_flight_time_sub.get().timestamp < 2_s) {
-		battery_usage_to_home = _rtl_flight_time_sub.get().rtl_limit_fraction;
-	}
-
-	uint8_t battery_range_warning = battery_status_s::BATTERY_WARNING_NONE;
-
-	if (PX4_ISFINITE(battery_usage_to_home)) {
-		float battery_at_home = battery_level - battery_usage_to_home;
-
-		if (battery_at_home < _param_bat_crit_thr.get()) {
-			battery_range_warning =  battery_status_s::BATTERY_WARNING_CRITICAL;
-
-		} else if (battery_at_home < _param_bat_low_thr.get()) {
-			battery_range_warning = battery_status_s::BATTERY_WARNING_LOW;
+		if (hrt_absolute_time() - _rtl_flight_time_sub.get().timestamp < 2_s) {
+			battery_usage_to_home = _rtl_flight_time_sub.get().rtl_limit_fraction;
 		}
-	}
 
-	if (battery_range_warning > worst_warning) {
-		worst_warning = battery_range_warning;
+		uint8_t battery_range_warning = battery_status_s::BATTERY_WARNING_NONE;
+
+		if (PX4_ISFINITE(battery_usage_to_home)) {
+			float battery_at_home = battery_level - battery_usage_to_home;
+
+			if (battery_at_home < _param_bat_crit_thr.get()) {
+				battery_range_warning =  battery_status_s::BATTERY_WARNING_CRITICAL;
+
+			} else if (battery_at_home < _param_bat_low_thr.get()) {
+				battery_range_warning = battery_status_s::BATTERY_WARNING_LOW;
+			}
+		}
+
+		if (battery_range_warning > worst_warning) {
+			worst_warning = battery_range_warning;
+		}
 	}
 
 	bool battery_warning_level_increased_while_armed = false;

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -214,6 +214,7 @@ private:
 		(ParamInt<px4::params::COM_POS_FS_GAIN>) _param_com_pos_fs_gain,
 
 		(ParamInt<px4::params::COM_LOW_BAT_ACT>) _param_com_low_bat_act,
+		(ParamInt<px4::params::COM_PRED_BAT_FS>) _param_com_pred_bat_fs,
 		(ParamFloat<px4::params::COM_DISARM_LAND>) _param_com_disarm_land,
 		(ParamFloat<px4::params::COM_DISARM_PRFLT>) _param_com_disarm_preflight,
 

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -340,6 +340,20 @@ PARAM_DEFINE_INT32(COM_ARM_SWISBTN, 0);
 PARAM_DEFINE_INT32(COM_LOW_BAT_ACT, 0);
 
 /**
+ * Predictive battery failsafe
+ *
+ * If this parameter is enabled, the battery failsafe action defined by COM_LOW_BAT_ACT will trigger predictively
+ * based on the estimated remaining state of charge after an RTL.
+ *
+ * @group Commander
+ * @value 0 Disabled
+ * @value 1 Enabled
+ * @decimal 0
+ * @increment 1
+ */
+PARAM_DEFINE_INT32(COM_PRED_BAT_FS, 1);
+
+/**
  * Time-out to wait when offboard connection is lost before triggering offboard lost action.
  *
  * See COM_OBL_ACT and COM_OBL_RC_ACT to configure action.


### PR DESCRIPTION
We want to disable the predictive battery failsafe since the predictiveness has false positives during the VTOL transition in certain wind conditions. This commit introduces the parameter COM_PRED_BAT_FS, which controls whether the predictive battery failsafe is enabled. 

I was not sure if introducing a new parameter was necessary, but I decided to do it since we may want to use the predictive feature for longer flights without the winching-related VTOL transitions.