### PR TITLE
FW landing bug fix

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -150,11 +150,12 @@ void VtolAttitudeControl::vehicle_cmd_poll()
 
 			uint8_t result = vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED;
 
-			// deny any transition in auto takeoff mode, plus transition from RW to FW in land or RTL mode
-			if (vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF
-			    || (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
-				&& (vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LAND
-				    || vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL))) {
+			// deny transition from MC to FW in Takeoff, Land, RTL and Orbit
+			if (int(vehicle_command.param1 + 0.5f) == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW &&
+			    (vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF
+			     || vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LAND
+			     || vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL
+			     ||  vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_ORBIT)) {
 
 				result = vehicle_command_ack_s::VEHICLE_RESULT_TEMPORARILY_REJECTED;
 


### PR DESCRIPTION
Cherry pick commit from source repository that should fix the FW landing bug.

I was able to reproduce FW landing twice in simulator, and verified that VtolAttitudeControl::vehicle_cmd_poll() rejects the transition commands when it happens. The fix is not tested in simulator, because the bug is very hard and random to reproduce. Before merge, we should try to consistently reproduce the bug in simulator and verify the fix, or if not possible, do a test flight.
