### PR TITLE
UPSTREAM PREVIEW: RTL fixes and improvements for VTOL vehicles

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -613,13 +613,7 @@ void RTL::advance_rtl()
 		break;
 
 	case RTL_STATE_RETURN:
-		if (vtol_in_fw_mode || descend_and_loiter) {
-			_rtl_state = RTL_STATE_DESCEND;
-
-		} else {
-			_rtl_state = RTL_STATE_LAND;
-		}
-
+		_rtl_state = RTL_STATE_DESCEND;
 		break;
 
 	case RTL_STATE_DESCEND:

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -49,6 +49,7 @@
 
 
 static constexpr float DELAY_SIGMA = 0.01f;
+static constexpr float ALT_SIGMA = 0.01f;
 
 using namespace time_literals;
 using namespace math;
@@ -326,6 +327,8 @@ void RTL::set_rtl_item()
 
 	const float destination_dist = get_distance_to_next_waypoint(_destination.lat, _destination.lon, gpos.lat, gpos.lon);
 	const float loiter_altitude = math::min(_destination.alt + _param_rtl_descend_alt.get(), _rtl_alt);
+	const float mc_descend_altitude_target = math::min(_destination.alt + _param_rtl_descend_mc.get(), gpos.alt);
+	const float mc_descend_altitude = math::min(mc_descend_altitude_target, _rtl_alt);
 
 	// if we will switch to mission for landing, already set the loiter radius (incl. direction) from mission
 	const float landing_loiter_radius = _destination.type == RTL_DESTINATION_MISSION_LANDING ?
@@ -538,6 +541,28 @@ void RTL::set_rtl_item()
 			break;
 		}
 
+	case RTL_STATE_MC_DESCEND: {
+			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
+			_mission_item.lat = _destination.lat;
+			_mission_item.lon = _destination.lon;
+
+			if (rtl_heading_mode == RTLHeadingMode::RTL_CURRENT_HEADING) {
+				_mission_item.yaw = _navigator->get_local_position()->heading;
+
+			} else {
+				_mission_item.yaw = _destination.yaw;
+			}
+
+			_mission_item.altitude = mc_descend_altitude;
+			_mission_item.altitude_is_relative = false;
+			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
+			_mission_item.origin = ORIGIN_ONBOARD;
+
+			mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: MC descend to %d m (%d m above destination)",
+					 (int)ceilf(_mission_item.altitude), (int)ceilf(_mission_item.altitude - _destination.alt));
+			break;
+		}
+
 	case RTL_STATE_LAND: {
 			// Land at destination.
 			_mission_item.nav_cmd = NAV_CMD_LAND;
@@ -600,12 +625,17 @@ void RTL::set_rtl_item()
 
 void RTL::advance_rtl()
 {
-	// determines if the vehicle should loiter above land
-	const bool descend_and_loiter = _param_rtl_land_delay.get() < -DELAY_SIGMA || _param_rtl_land_delay.get() > DELAY_SIGMA;
+	// vehicle is a VTOL, either in FW or MC mode
+	const bool is_vtol = _navigator->get_vstatus()->is_vtol;
 
-	// vehicle is a vtol and currently in fixed wing mode
-	const bool vtol_in_fw_mode = _navigator->get_vstatus()->is_vtol
-				     && _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING;
+	// vehicle is FW, which could be a VTOL in FW mode
+	const bool is_fw = _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING;
+
+	// determines if the vehicle should loiter above land, only relevant in FW
+	const bool do_fw_loiter = _param_rtl_land_delay.get() < -DELAY_SIGMA || _param_rtl_land_delay.get() > DELAY_SIGMA;
+
+	// determines if the vehicle should descent in MC before land
+	const bool do_mc_descend = _param_rtl_descend_mc.get() > ALT_SIGMA;
 
 	switch (_rtl_state) {
 	case RTL_STATE_CLIMB:
@@ -613,49 +643,64 @@ void RTL::advance_rtl()
 		break;
 
 	case RTL_STATE_RETURN:
-		_rtl_state = RTL_STATE_DESCEND;
+		if (is_fw) {
+			_rtl_state = RTL_STATE_DESCEND;
+
+		} else if (do_mc_descend) {
+			_rtl_state = RTL_STATE_MC_DESCEND;
+
+		} else {  // MC with RTL_DESCEND_MC <= 0
+			_rtl_state = RTL_STATE_LAND;
+		}
+
 		break;
 
 	case RTL_STATE_DESCEND:
-
-		if (descend_and_loiter) {
+		if (do_fw_loiter) {
 			_rtl_state = RTL_STATE_LOITER;
 
-		} else if (vtol_in_fw_mode) {
+		} else if (is_fw && is_vtol) {
 			_rtl_state = RTL_STATE_HEAD_TO_CENTER;
 
-		} else {
+		} else if (!is_fw && do_mc_descend) {
+			_rtl_state = RTL_STATE_MC_DESCEND;
+
+		} else {  // FW and not VTOL
 			_rtl_state = RTL_STATE_LAND;
 		}
 
 		break;
 
 	case RTL_STATE_LOITER:
-
-		if (vtol_in_fw_mode) {
+		if (is_vtol) {
 			_rtl_state = RTL_STATE_HEAD_TO_CENTER;
+
+		} else {  // FW and not VTOL
+			_rtl_state = RTL_STATE_LAND;
+		}
+
+		break;
+
+	case RTL_STATE_HEAD_TO_CENTER:
+		_rtl_state = RTL_STATE_TRANSITION_TO_MC;
+		break;
+
+	case RTL_STATE_TRANSITION_TO_MC:
+		_rtl_state = RTL_MOVE_TO_LAND_HOVER_VTOL;
+		break;
+
+	case RTL_MOVE_TO_LAND_HOVER_VTOL:
+		if (do_mc_descend) {
+			_rtl_state = RTL_STATE_MC_DESCEND;
 
 		} else {
 			_rtl_state = RTL_STATE_LAND;
 		}
-		break;
-
-	case RTL_STATE_HEAD_TO_CENTER:
-
-		_rtl_state = RTL_STATE_TRANSITION_TO_MC;
 
 		break;
 
-	case RTL_STATE_TRANSITION_TO_MC:
-
-		_rtl_state = RTL_MOVE_TO_LAND_HOVER_VTOL;
-
-		break;
-
-	case RTL_MOVE_TO_LAND_HOVER_VTOL:
-
+	case RTL_STATE_MC_DESCEND:
 		_rtl_state = RTL_STATE_LAND;
-
 		break;
 
 	case RTL_STATE_LAND:
@@ -769,6 +814,7 @@ void RTL::calc_and_pub_rtl_time_estimate(const RTLState rtl_state)
 
 		// FALLTHROUGH
 		case RTL_MOVE_TO_LAND_HOVER_VTOL:
+		case RTL_STATE_MC_DESCEND:
 		case RTL_STATE_LAND: {
 				float initial_altitude;
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -644,8 +644,6 @@ void RTL::advance_rtl()
 		} else {
 			_rtl_state = RTL_STATE_LAND;
 		}
-
-		_rtl_state = RTL_STATE_LAND;
 		break;
 
 	case RTL_STATE_HEAD_TO_CENTER:

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -503,7 +503,10 @@ void RTL::set_rtl_item()
 			} else if (rtl_heading_mode == RTLHeadingMode::RTL_CURRENT_HEADING) {
 				_mission_item.yaw = _navigator->get_local_position()->heading;
 			}
-
+			
+			_mission_item.vtol_back_transition = true;
+			// acceptance_radius will be overwritten since vtol_back_transition is set,
+			// set as a default value only
 			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
 			_mission_item.time_inside = 0.0f;
 			_mission_item.autocontinue = true;

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -639,7 +639,7 @@ void RTL::advance_rtl()
 	case RTL_STATE_LOITER:
 
 		if (vtol_in_fw_mode) {
-			_rtl_state = RTL_STATE_TRANSITION_TO_MC;
+			_rtl_state = RTL_STATE_HEAD_TO_CENTER;
 
 		} else {
 			_rtl_state = RTL_STATE_LAND;

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -93,6 +93,7 @@ public:
 		RTL_STATE_LAND,
 		RTL_STATE_LANDED,
 		RTL_STATE_HEAD_TO_CENTER,
+		RTL_STATE_MC_DESCEND,
 	};
 
 	void on_inactivation() override;
@@ -166,6 +167,7 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::RTL_RETURN_ALT>)  _param_rtl_return_alt,
 		(ParamFloat<px4::params::RTL_DESCEND_ALT>) _param_rtl_descend_alt,
+		(ParamFloat<px4::params::RTL_DESCEND_MC>)  _param_rtl_descend_mc,
 		(ParamFloat<px4::params::RTL_LAND_DELAY>)  _param_rtl_land_delay,
 		(ParamFloat<px4::params::RTL_MIN_DIST>)    _param_rtl_min_dist,
 		(ParamInt<px4::params::RTL_TYPE>)          _param_rtl_type,

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -65,6 +65,7 @@ PARAM_DEFINE_FLOAT(RTL_RETURN_ALT, 60.f);
  * Descend to this altitude (above destination position) after return, and wait for time defined in RTL_LAND_DELAY.
  * Land (i.e. slowly descend) from this altitude if autolanding allowed.
  * VTOLs do transition to hover in this altitdue above the landing point.
+ * Only used for FW vehicles (including VTOL in FW mode).
  *
  * @unit m
  * @min 0
@@ -79,6 +80,7 @@ PARAM_DEFINE_FLOAT(RTL_DESCEND_ALT, 30.f);
  *
  * Delay before landing (after initial descent) in Return mode.
  * If set to -1 the system will not land but loiter at RTL_DESCEND_ALT.
+ * Only used for FW vehicles (including VTOL in FW mode).
  *
  * @unit s
  * @min -1
@@ -87,6 +89,26 @@ PARAM_DEFINE_FLOAT(RTL_DESCEND_ALT, 30.f);
  * @group Return Mode
  */
 PARAM_DEFINE_FLOAT(RTL_LAND_DELAY, 0.0f);
+
+/**
+ * Return mode MC descend altitude
+ *
+ * Descend to this altitude (above destination position) before starting the actual landing.
+ * Only for MC vehicles (including VTOL in MC mode).
+ * For VTOLs that start RTL in FW, the vehicle will descend to this altitide
+ * after loitering at RTL_RETURN_ALT in FW and transition to MC.
+ * This allows for a faster MC descent than the landing speed to conserve battery,
+ * while still setting RTL_DESCEND_ALT at an altitude high enough for safe FW loitering.
+ * Set to -1 to disable. Should be less than RTL_DESCEND_ALT if vehicle is VTOL.
+ *
+ * @unit m
+ * @min -1
+ * @max 100
+ * @decimal 1
+ * @increment 0.5
+ * @group Return Mode
+ */
+PARAM_DEFINE_FLOAT(RTL_DESCEND_MC, -1.0f);
 
 /**
  * Horizontal radius from return point within which special rules for return mode apply.


### PR DESCRIPTION
This is not supposed to be merged, but is rather a preview of the coming upstream PR. The commits are adapted from #10.

**Describe problem solved by this pull request**
The main problem I set out to solve was that a VTOL RTL is too slow/consumes to much battery when landing at rally points with altitude different than home altitude. This is because MPC_LAND_ALT1/MPC_LAND_ALT2 do not consider rally point altitude, and it is therefor not possible to tune the land and descend speeds so that you get both a soft landing and a fast descent until you are close to the ground. For VTOLs we can not use RTL_DESCEND_ALT for this wither, since it must be set high enough for a safe FW loiter, which can be too high to do a slow MC descend from.

During this process, I found other issues with RTL that I have addressed as well:
  - If RTL_LAND_DELAY > 0, VTOLs will do a FW landing, this bug was introduces in https://github.com/PX4/PX4-Autopilot/pull/16582
  - RTL_STATE_HEAD_TO_CENTER is dependent on whether to loiter or not. It would be desired to have same functionality for  VTOL transition/movement no matter if loiter is used or not.
  - MC and VTOL in MC will skip descend state if there is no loiter. I under stand the rationale that in most cases the behavior will be almost the same if MPC_LAND_ALT1/MPC_LAND_ALT2 is set correctly, but as described above this is not possible for rally points with altitude different than home.
  - Acceptance radius for VTOL landing in RTL is different than normal VTOL landing, since state prior to VTOL transition do not set _mission_item.vtol_back_transition. This can cause some overshoot and possible unnecessarily aggressive maneuvering.

**Describe your solution**
The main issue is fixed by introducing a new parameter RTL_DESCEND_MC and a new RTL state RTL_STATE_MC_DESCEND. RTL_DESCEND_MC gives an altitude for a MC (or VTOL in MC) to descend to (at speed MPC_Z_V_AUTO_DN) before starting the landing (at a slower speed). For VTOL in FW, this state will be entered after first descending to RTL_DESCEND_ALT and loiter and transition to MC. For MC and VTOL in MC, this state will be entered after return. That means that RTL_DESCEND_ALT and RTL_LAND_DELAY will not be used at all for MC.

**Describe possible alternatives**
MPC_LAND_ALT1/MPC_LAND_ALT2 could be fixed to account for rally point altitude, which may solve some, but not all RTL VTOL issues.

**Test data / coverage**
Tested in simulator with standard VTOL.
Could use some help to test pure MC and FW behavior.

**Additional context**
RTL time prediction is not changed. The prediction seems to be fairly rough for VTOL anyway, so I consider it safe to ignore the these changes and they will not make the RTL time worse.
