### PR TITLE
Logging fixes for 1.13

### DIFF
--- a/boards/cubepilot/cubeorange/init/rc.board_defaults
+++ b/boards/cubepilot/cubeorange/init/rc.board_defaults
@@ -15,3 +15,5 @@ param set-default SENS_EN_THERMAL 0
 param set-default -s SENS_TEMP_ID 2621474
 
 set IOFW "/etc/extras/cubepilot_io-v2_default.bin"
+
+set LOGGER_BUF 128

--- a/src/modules/mavlink/mavlink_log_handler.cpp
+++ b/src/modules/mavlink/mavlink_log_handler.cpp
@@ -146,7 +146,7 @@ MavlinkLogHandler::_log_request_list(const mavlink_message_t *msg)
 	//-- Check for re-requests (data loss) or new request
 	if (_current_status != LogHandlerState::Inactive) {
 		//-- Is this a new request?
-		if ((request.end - request.start) > _log_count) {
+		if (request.start == 0) {
 			_current_status = LogHandlerState::Inactive;
 			_close_and_unlink_files();
 

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1835,6 +1835,27 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 int
 Mavlink::task_main(int argc, char *argv[])
 {
+	// If stdin, stdout and/or stderr file descriptors (0, 1, 2)
+	// are not open when mavlink module starts (as might be the case for USB auto-start),
+	// use default /dev/null so that these numbers are not used by other other files.
+	if (fcntl(0, F_GETFD) == -1) {
+		int tmp = open("/dev/null", O_RDONLY);
+		dup2(tmp, 0);
+		close(tmp);
+	}
+
+	if (fcntl(1, F_GETFD) == -1) {
+		int tmp = open("/dev/null", O_WRONLY);
+		dup2(tmp, 1);
+		close(tmp);
+	}
+
+	if (fcntl(2, F_GETFD) == -1) {
+		int tmp = open("/dev/null", O_WRONLY);
+		dup2(tmp, 2);
+		close(tmp);
+	}
+
 	int ch;
 	_baudrate = 57600;
 	_datarate = 0;


### PR DESCRIPTION
Note: Two of these fixes are on review upstream. Log buffer increase is only in our repo.

When increasing the log buffer size, the total RAM goes from ~45% to ~55%. The RAM usage is very stable, so this change should be fine. The previous (default) log size is 64KiB, this change doubles that to 128KiB.

For other fixes, this description is copied from upstream PR:

### Solved Problem
When upgrading a cube orange to 1.13 we found log download by USB to not work when there was 50 or more logs on the target. In addition for less than 50 logs, it is necessary to request the list of logs two times for it to be generated. This is assuming we use QGroundControl (which requests 50 entries at a time with LOG_REQUEST_LIST), and USB connection.

There is two issues that cases this:

- When opening the mavlink module by USB auto-start (from https://github.com/PX4/PX4-Autopilot/pull/16180) stdout and stderr is not open (unsure if stderr is a problem). This would cause file descriptor 1 to be reused when generating the log list, and the log list would be corrupted by an other part of the module erroneously writing to stdout. I could not replicate this in main, but I believe this is due to coincidence, and not it actually being fixed.
- When receiving a LOG_REQUEST_LIST, the module assumes that when asking for more entries than currently exist, it indicates a new request, rather than pagination. This is a strange assumption, I feel, but I do not know where it originates from, and what the reason might be.

### Solution
- Open default file descriptors (/dev/null) when starting mavlink module, if 0, 1 and/or 2 is not open.
- Use start index in LOG_REQUEST_LIST to determine if this is a new request, and log list should be regenerated.

Note, this also fixes the mavlink shell stall on cube orange, so https://github.com/PX4/PX4-Autopilot/pull/20824 should not be needed (but does now harm as far as I know).

### Alternatives
Regarding the file descriptors, they could be fixed in the usb auto start section instead. I am not sure what would be the best approach.