### PR TITLE
mixer_module: only advertise actuator_outputs when mixer is loaded

### DIFF
--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -48,8 +48,8 @@ jobs:
           ccache -s
           ccache -z
 
-    - name: make all_variants_${{matrix.config}}
-      run: make all_variants_${{matrix.config}}
+    - name: make ${{matrix.config}}
+      run: make ${{matrix.config}}_default
       timeout-minutes: 45
     - name: make ${{matrix.config}} bloaty_compileunits
       run: make ${{matrix.config}} bloaty_compileunits || true

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -103,12 +103,12 @@ _param_prefix(param_prefix)
 		}
 
 		updateParams();
+		_outputs_pub.advertise();
 
 	} else {
 		_control_allocator_status_pub.advertise();
 	}
 
-	_outputs_pub.advertise();
 }
 
 MixingOutput::~MixingOutput()
@@ -1239,6 +1239,7 @@ int MixingOutput::loadMixer(const char *buf, unsigned len)
 	_mixers->groups_required(_groups_required);
 	PX4_DEBUG("loaded mixers \n%s\n", buf);
 
+	_outputs_pub.advertise();
 	updateParams();
 	_interface.mixerChanged();
 	return ret;


### PR DESCRIPTION
Cherry pick from release/1.13 branch (after v1.13.2 release).

This fixes that pwm main/aux is allocated to actuator_outputs_2/3 instead of expected 0/1, because 0/1 is allocated to unused uavcan pwn outputs.

Fixing this uORB message, will fix both log and Mavlink message SERVO_OUTPUT_RAW.
