### PR TITLE
Fix return to home if reposition outside geofence

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -548,12 +548,6 @@ void Navigator::run()
 				// reset cruise speed and throttle to default when transitioning (VTOL Takeoff handles it separately)
 				reset_cruising_speed();
 				set_cruising_throttle();
-
-				// need to update current setpooint with reset cruise speed and throttle
-				position_setpoint_triplet_s *rep = get_reposition_triplet();
-				*rep = *(get_position_setpoint_triplet());
-				rep->current.cruising_speed = get_cruising_speed();
-				rep->current.cruising_throttle = get_cruising_throttle();
 			}
 		}
 


### PR DESCRIPTION
In 1.13, if reposition outside geofence during a mission with VTOL transition, the drone will return to home and circle there in a very tight circle, rather than loiter at current position as is behavior in 1.12 and main.

This behavior does not happen if a valid reposition, or one of a number of other commands are given prior to the reposition outside the geofence.

The cherry picked commit fixes the 1.13 behavior to be as expected.
![Screenshot from 2023-02-15 13-44-34](https://user-images.githubusercontent.com/108630475/219032300-961c8d18-7b07-4b50-a4a9-41815a29db0a.png)

Screenshot is from simulator, but the same behavior can be found in https://fms.aviant.no/flight/2329/show