### PR TITLE
Distance sensor 1.13 issue quick fix

### DIFF
--- a/platforms/nuttx/src/px4/common/px4_init.cpp
+++ b/platforms/nuttx/src/px4/common/px4_init.cpp
@@ -140,19 +140,22 @@ int px4_platform_init()
 		I2C_RESET(i2c_dev);
 #endif // CONFIG_I2C_RESET
 
+		// This causes LW20/C distance sensor for some setups to garble up the bus
+		// Disable for now for external bus,
+		// we can investigate if a FW update of the sensor fixes this later
 		// send software reset to all
-		uint8_t buf[1] {};
-		buf[0] = 0x06; // software reset
+		// uint8_t buf[1] {};
+		// buf[0] = 0x06; // software reset
 
-		i2c_msg_s msg{};
-		msg.frequency = I2C_SPEED_STANDARD;
-		msg.addr = 0x00; // general call address
-		msg.buffer = &buf[0];
-		msg.length = 1;
+		// i2c_msg_s msg{};
+		// msg.frequency = I2C_SPEED_STANDARD;
+		// msg.addr = 0x00; // general call address
+		// msg.buffer = &buf[0];
+		// msg.length = 1;
 
-		I2C_TRANSFER(i2c_dev, &msg, 1);
+		// I2C_TRANSFER(i2c_dev, &msg, 1);
 
-		px4_i2cbus_uninitialize(i2c_dev);
+		// px4_i2cbus_uninitialize(i2c_dev);
 	}
 
 #endif // CONFIG_I2C


### PR DESCRIPTION
For some reason, the same behavior is hard to get on a test setup connected directly to the cube, but it is very repeatable on NT11. It could be that the length of wires impacts the cubes ability to pull down I2C lines.

I2C data line is pulled up by distance sensor after this command, so that it will not reach 0 (rather about 1 - 1.5 V) when the master try to send. It might be that the distance sensor enters UART mode, but this is not verified.

Unplugging/re-plugging the distance sensor after boot fixes this, and everything runs normal after (after manually restarting drivers for airspeed and distance sensor).

The fix impacts start up only, so it will be safe in air, as long as all drivers started as expected.
