### PR TITLE
1.13 loiter to altitude issue

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -301,40 +301,7 @@ MissionBlock::is_mission_item_reached()
 
 			}
 
-			bool passed_curr_wp = false;
-
-			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
-
-				const float dist_prev_to_curr = get_distance_to_next_waypoint(_navigator->get_position_setpoint_triplet()->previous.lat,
-								_navigator->get_position_setpoint_triplet()->previous.lon, _navigator->get_position_setpoint_triplet()->current.lat,
-								_navigator->get_position_setpoint_triplet()->current.lon);
-
-				if (dist_prev_to_curr > 1.0e-6f && _navigator->get_position_setpoint_triplet()->previous.valid) {
-					// Fixed-wing guidance interprets this condition as line segment following
-
-					// vector from previous waypoint to current waypoint
-					float vector_prev_to_curr_north;
-					float vector_prev_to_curr_east;
-					get_vector_to_next_waypoint_fast(_navigator->get_position_setpoint_triplet()->previous.lat,
-									 _navigator->get_position_setpoint_triplet()->previous.lon, _navigator->get_position_setpoint_triplet()->current.lat,
-									 _navigator->get_position_setpoint_triplet()->current.lon, &vector_prev_to_curr_north,
-									 &vector_prev_to_curr_east);
-
-					// vector from next waypoint to aircraft
-					float vector_curr_to_vehicle_north;
-					float vector_curr_to_vehicle_east;
-					get_vector_to_next_waypoint_fast(_navigator->get_position_setpoint_triplet()->current.lat,
-									 _navigator->get_position_setpoint_triplet()->current.lon, _navigator->get_global_position()->lat,
-									 _navigator->get_global_position()->lon, &vector_curr_to_vehicle_north,
-									 &vector_curr_to_vehicle_east);
-
-					// if dot product of vectors is positive, we are passed the current waypoint (the terminal point on the line segment) and should switch to next mission item
-					passed_curr_wp = vector_prev_to_curr_north * vector_curr_to_vehicle_north + vector_prev_to_curr_east *
-							 vector_curr_to_vehicle_east > 0.0f;
-				}
-			}
-
-			if (dist_xy >= 0.0f && (dist_xy <= acceptance_radius || passed_curr_wp) && dist_z <= alt_acc_rad_m) {
+			if (dist_xy >= 0.0f && dist_xy <= acceptance_radius && dist_z <= alt_acc_rad_m) {
 				_waypoint_position_reached = true;
 			}
 		}


### PR DESCRIPTION
This PR reverts part of changed to WP acceptance check introduced between 1.12 and 1.13, so that the loiter to altitude (when WP altitude is not reached) have the same end behavior.

Before (1.13 behavior):
![image](https://user-images.githubusercontent.com/108630475/226354995-60e01789-3bda-4c6b-8c77-a58902febc3e.png)

After (same as 1.12):
![image](https://user-images.githubusercontent.com/108630475/226355273-b0bd6f59-c573-4884-b91b-29f32c773abc.png)

For comparison, master branch, which have similar 1.12 behavior, but this is unintended, because of a bug:
![image](https://user-images.githubusercontent.com/108630475/226562322-e03d03d5-8b21-43e0-9b52-98f4db593dd9.png)

