### PR TITLE
Draft: MPC_Z_VEL_MAX_* resolution metadata

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -191,6 +191,7 @@ PARAM_DEFINE_FLOAT(MPC_Z_VEL_D_ACC, 0.0f);
  * @unit m/s
  * @min 0.5
  * @max 8.0
+ * @increment 0.1
  * @decimal 1
  * @group Multicopter Position Control
  */
@@ -204,6 +205,8 @@ PARAM_DEFINE_FLOAT(MPC_Z_VEL_MAX_UP, 3.0f);
  * @unit m/s
  * @min 0.5
  * @max 4.0
+ * @increment 0.1
+ * @decimal 1
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_FLOAT(MPC_Z_VEL_MAX_DN, 1.0f);


### PR DESCRIPTION
This fix is only needed for 1.12, it is correct in 1.13.

This fix is only needed if we need to adjust MPC_Z_VEL_MAX_UP/MPC_Z_VEL_MAX_DN to a non-integer number, keep this PR as draft for now.

The changes are only relevant for setting/showing the parameters in QGC, the behavior shall be identical.