### PR TITLE
Send parachute command on disarm in air

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -894,6 +894,10 @@ Commander::handle_command(const vehicle_command_s &cmd)
 					} else {
 						arming_res = disarm(arm_disarm_reason_t::COMMAND_INTERNAL);
 					}
+
+					if (arming_res == TRANSITION_CHANGED && !_land_detector.landed) {
+						send_parachute_command();
+					}
 				}
 
 				if (arming_res == TRANSITION_DENIED) {


### PR DESCRIPTION
QGC does not send "Terminate", but disarm signal.
When disarming in the air, we should trigger parachute.

Alternative solution:
Modify QGC to send terminate.

To be tested:
- [x] Test in simulator that parachute triggers always when disarmed in the air, and never when disarmed on the ground
- [ ] Test on NX02 in lab
- [ ] Test on NX02 palltest
- [ ] Test on NX02 in air