### PR TITLE
Send parachute command on disarm in air - 1.13

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1018,6 +1018,10 @@ Commander::handle_command(const vehicle_command_s &cmd)
 				} else if (arming_action == vehicle_command_s::ARMING_ACTION_DISARM) {
 					arming_res = disarm(arm_disarm_reason, forced);
 
+					if (arming_res == TRANSITION_CHANGED && !_vehicle_land_detected.landed) {
+						send_parachute_command();
+					}
+
 				}
 
 				if (arming_res == TRANSITION_DENIED) {

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -217,6 +217,8 @@ private:
 
 		(ParamBool<px4::params::COM_OBS_AVOID>) _param_com_obs_avoid,
 
+		(ParamInt<px4::params::COM_PARACHUTE>) _param_com_parachute,
+
 		(ParamInt<px4::params::COM_FLT_PROFILE>) _param_com_flt_profile,
 
 		(ParamFloat<px4::params::COM_OBC_LOSS_T>) _param_com_obc_loss_t,


### PR DESCRIPTION
#23 ported to 1.13

Also add missing definition of COM_PARACHUTE, so that this parameter is available to set (require healthy parachute to arm).