### PR TITLE
Failure detection for vertical rate

### DIFF
--- a/msg/failure_detector_status.msg
+++ b/msg/failure_detector_status.msg
@@ -9,5 +9,6 @@ bool fd_arm_escs
 bool fd_high_wind
 bool fd_battery
 bool fd_imbalanced_prop
+bool fd_mpc_vz
 
 float32 imbalanced_prop_metric      # Metric of the imbalanced propeller check (low-passed)

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2861,7 +2861,8 @@ Commander::run()
 					}
 				}
 
-				if (fd_status_flags.roll || fd_status_flags.pitch || fd_status_flags.alt || fd_status_flags.ext) {
+				if (fd_status_flags.roll || fd_status_flags.pitch || fd_status_flags.alt || fd_status_flags.ext
+				    || fd_status_flags.mpc_vz) {
 					const bool is_right_after_takeoff = hrt_elapsed_time(&_status.takeoff_time) < (1_s * _param_com_lkdown_tko.get());
 
 					if (is_right_after_takeoff && !_lockdown_triggered) {
@@ -3078,6 +3079,7 @@ Commander::run()
 			fd_status.fd_battery = _failure_detector.getStatusFlags().battery;
 			fd_status.fd_imbalanced_prop = _failure_detector.getStatusFlags().imbalanced_prop;
 			fd_status.imbalanced_prop_metric = _failure_detector.getImbalancedPropMetric();
+			fd_status.fd_mpc_vz = _failure_detector.getStatusFlags().mpc_vz;
 			_failure_detector_status_pub.publish(fd_status);
 		}
 

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -59,6 +59,8 @@
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/esc_status.h>
 #include <uORB/topics/pwm_input.h>
+#include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_local_position_setpoint.h>
 
 union failure_detector_status_u {
 	struct {
@@ -70,6 +72,7 @@ union failure_detector_status_u {
 		uint16_t high_wind : 1;
 		uint16_t battery : 1;
 		uint16_t imbalanced_prop : 1;
+		uint16_t mpc_vz : 1;
 	} flags;
 	uint16_t value {0};
 };
@@ -91,6 +94,7 @@ private:
 	void updateExternalAtsStatus();
 	void updateEscsStatus(const vehicle_status_s &vehicle_status);
 	void updateImbalancedPropStatus();
+	void updateMpcVerticalRateStatus();
 
 	failure_detector_status_u _status{};
 
@@ -98,6 +102,7 @@ private:
 	systemlib::Hysteresis _pitch_failure_hysteresis{false};
 	systemlib::Hysteresis _ext_ats_failure_hysteresis{false};
 	systemlib::Hysteresis _esc_failure_hysteresis{false};
+	systemlib::Hysteresis _mpc_vz_failure_hysteresis{false};
 
 	static constexpr float _imbalanced_prop_lpf_time_constant{5.f};
 	AlphaFilter<float> _imbalanced_prop_lpf{};
@@ -109,6 +114,8 @@ private:
 	uORB::Subscription _pwm_input_sub{ORB_ID(pwm_input)};
 	uORB::Subscription _sensor_selection_sub{ORB_ID(sensor_selection)};
 	uORB::Subscription _vehicle_imu_status_sub{ORB_ID(vehicle_imu_status)};
+	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
+	uORB::Subscription _vehicle_local_position_setpoint_sub{ORB_ID(vehicle_local_position_setpoint)};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::FD_FAIL_P>) _param_fd_fail_p,
@@ -118,6 +125,8 @@ private:
 		(ParamBool<px4::params::FD_EXT_ATS_EN>) _param_fd_ext_ats_en,
 		(ParamInt<px4::params::FD_EXT_ATS_TRIG>) _param_fd_ext_ats_trig,
 		(ParamInt<px4::params::FD_ESCS_EN>) _param_escs_en,
-		(ParamInt<px4::params::FD_IMB_PROP_THR>) _param_fd_imb_prop_thr
+		(ParamInt<px4::params::FD_IMB_PROP_THR>) _param_fd_imb_prop_thr,
+		(ParamInt<px4::params::FD_MPC_VZ_THR>) _param_fd_mpc_vz_thr,
+		(ParamFloat<px4::params::FD_MPC_VZ_TTRI>) _param_fd_mpc_vz_ttri
 	)
 };

--- a/src/modules/commander/failure_detector/failure_detector_params.c
+++ b/src/modules/commander/failure_detector/failure_detector_params.c
@@ -156,3 +156,31 @@ PARAM_DEFINE_INT32(FD_ESCS_EN, 1);
  * @group Failure Detector
  */
 PARAM_DEFINE_INT32(FD_IMB_PROP_THR, 30);
+
+/**
+ * Multicopter altitude rate fail threshold
+ *
+ * Maximum downwards vertical velocity before FailureDetector triggers the vertical_rate_failure flag.
+ * Will only be triggered if the setpoint is negative (ascending).
+ * Set to 0 to disable.
+ *
+ * @min 0
+ * @max 20
+ * @increment 1
+ * @group Failure Detector
+ */
+PARAM_DEFINE_INT32(FD_MPC_VZ_THR, 0);
+
+/**
+ * Multicopter altitude rate fail trigger time
+ *
+ * Seconds (decimal) that vertical rate has to exceed FD_MPC_VZ_THR before being considered as a failure.
+ *
+ * @unit s
+ * @min 0.02
+ * @max 5
+ * @decimal 2
+ *
+ * @group Failure Detector
+ */
+PARAM_DEFINE_FLOAT(FD_MPC_VZ_TTRI, 0.3);


### PR DESCRIPTION
New parameters:
- `FD_MPC_VZ_THR` Threshold - descend at at least this velocity while setpoint is "ascending"
- `FD_MPC_VZ_TTRI` Trigger time - conditions must be active for at least this long

Other relevant parameters:
- `COM_LKDOWN_TKO` If takeoff was within this time, failure detection will trigger lookdown
- `CBRK_FLIGHTTERM` Set to 0 to enable failure detector to terminate flight (if COM_LKDOWN_TKO have passed)

Note: We might want to increase COM_LKDOWN_TKO, as a parachute deployment within the current used 3 seconds probably won't do any good.