### PR TITLE
Do not deploy parachute on disarm right after takeoff

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1017,8 +1017,9 @@ Commander::handle_command(const vehicle_command_s &cmd)
 
 				} else if (arming_action == vehicle_command_s::ARMING_ACTION_DISARM) {
 					arming_res = disarm(arm_disarm_reason, forced);
+					const bool is_right_after_takeoff = hrt_elapsed_time(&_status.takeoff_time) < (1_s * _param_com_lkdown_tko.get());
 
-					if (arming_res == TRANSITION_CHANGED && !_vehicle_land_detected.landed) {
+					if (arming_res == TRANSITION_CHANGED && !_vehicle_land_detected.landed && !is_right_after_takeoff) {
 						send_parachute_command();
 					}
 


### PR DESCRIPTION
Use COM_LKDOWN_TKO when a disarm while in the air is received to decide if the parachute should be deployed.

Currently, if the drone detect takeoff right after landing (possibly due to landing on uneven ground), the pilot will manually disarm the drone. This may trigger the parachute. This PR, in combination with increasing COM_LKDOWN_TKO will fix this.