### PR TITLE
commander: add ground distance check to prevent flight termination

### DIFF
--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -327,6 +327,7 @@ private:
 	bool		_flight_termination_triggered{false};
 	bool		_lockdown_triggered{false};
 	bool            _imbalanced_propeller_check_triggered{false};
+	bool		_failure_detector_msg_flag{false};
 
 
 	hrt_abstime	_datalink_last_heartbeat_gcs{0};

--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -80,7 +80,23 @@ bool FailureDetector::update(const vehicle_status_s &vehicle_status, const vehic
 		_status.flags.mpc_vz = false;
 	}
 
+	updateTerminationAllowedStatus();
+
 	return _status.value != status_prev.value;
+}
+
+void FailureDetector::updateTerminationAllowedStatus()
+{
+	vehicle_local_position_s local_position;
+	_vehicle_local_position_sub.copy(&local_position);
+
+	// If the measurement is valid and under the distance threshold, flight termination is not allowed, otherwise it is.
+	if (local_position.dist_bottom_valid && (local_position.dist_bottom < _param_fd_min_dist_trm_p.get())) {
+		_termination_allowed = false;
+
+	} else {
+		_termination_allowed = true;
+	}
 }
 
 void FailureDetector::updateAttitudeStatus()

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -85,11 +85,13 @@ public:
 	FailureDetector(ModuleParams *parent);
 
 	bool update(const vehicle_status_s &vehicle_status, const vehicle_control_mode_s &vehicle_control_mode);
+	bool getTerminationAllowed() {return _termination_allowed; };
 	const failure_detector_status_u &getStatus() const { return _status; }
 	const decltype(failure_detector_status_u::flags) &getStatusFlags() const { return _status.flags; }
 	float getImbalancedPropMetric() const { return _imbalanced_prop_lpf.getState(); }
 
 private:
+	void updateTerminationAllowedStatus();
 	void updateAttitudeStatus();
 	void updateExternalAtsStatus();
 	void updateEscsStatus(const vehicle_status_s &vehicle_status);
@@ -104,6 +106,7 @@ private:
 	systemlib::Hysteresis _esc_failure_hysteresis{false};
 	systemlib::Hysteresis _mpc_vz_failure_hysteresis{false};
 
+	bool _termination_allowed{false}; ///< Flag indicating if preconditions for flight termination are satisfied
 	static constexpr float _imbalanced_prop_lpf_time_constant{5.f};
 	AlphaFilter<float> _imbalanced_prop_lpf{};
 	uint32_t _selected_accel_device_id{0};
@@ -118,6 +121,7 @@ private:
 	uORB::Subscription _vehicle_local_position_setpoint_sub{ORB_ID(vehicle_local_position_setpoint)};
 
 	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::FD_MIN_DIST_TRM>) _param_fd_min_dist_trm_p,
 		(ParamInt<px4::params::FD_FAIL_P>) _param_fd_fail_p,
 		(ParamInt<px4::params::FD_FAIL_R>) _param_fd_fail_r,
 		(ParamFloat<px4::params::FD_FAIL_R_TTRI>) _param_fd_fail_r_ttri,

--- a/src/modules/commander/failure_detector/failure_detector_params.c
+++ b/src/modules/commander/failure_detector/failure_detector_params.c
@@ -43,6 +43,22 @@
 #include <parameters/param.h>
 
 /**
+ * Minimum Ground Distance For Termination
+ *
+ * The value has implications for determining whether the flight termination action will occur.
+ * If a failure is detected and the vehicle's distance from the ground exceeds this parameter's value,
+ * termination will be executed. Otherwise, if the distance is less than the parameter value,
+ * the failure detector values will only be logged.
+ *
+ * @decimal 2
+ * @min 0.00
+ * @max 10000.00
+ * @unit m
+ * @group Failure Detector
+ */
+PARAM_DEFINE_FLOAT(FD_MIN_DIST_TRM, 0.00);
+
+/**
  * FailureDetector Max Roll
  *
  * Maximum roll angle before FailureDetector triggers the attitude_failure flag.


### PR DESCRIPTION
This solution introduces the parameter **FD_MIN_DIST_TRM**, which acts as the minimum distance from the ground required for triggering the failsafe. If the vehicle's distance from the ground is below the specified threshold, the termination will not activate. However, the pilot will receive a warning indicating a detected anomaly, and the failure will be logged within the system for future debugging purposes.

To implement this logic, two values from the uORB message `vehicle_local_position` were utilized:

-  The `dist_bottom` parameter determines the vertical distance between the vehicle and the ground. This value is a filtered result from the distance sensor, merged with IMU data. This approach ensures that any short-term errors from the distance sensor won't introduce inaccuracies into the system.

-  The `dist_bottom_valid` parameter is computed within the EKF and signifies the reliability of the `dist_bottom` value. If uncertainty rises, `dist_bottom_valid` will be set to a `false`.

Table of truth:
| dist_bottom_valid | dist_bottom <  FD_MIN_DIST_TRM| flight termination |
| ------------- | ------------- | ------------- |
| false  | false |true|
| false  | true |true|
| true  | false |true|
| true  | true |false|

The test is performed by injecting different `dist_bottom_valid` and failure detect values in SITL.  
