### PR TITLE
Custom mavlink mode for parachute

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1679,10 +1679,12 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		break;
 
 	case MAVLINK_MODE_MAGIC:
-
-	/* fallthrough */
-	case MAVLINK_MODE_CUSTOM:
 		//stream nothing
+		break;
+
+	case MAVLINK_MODE_CUSTOM:
+		configure_stream_local("ATTITUDE", 10.0f);
+		configure_stream_local("TIMESYNC", 1.0f);
 		break;
 
 	case MAVLINK_MODE_CONFIG: // USB


### PR DESCRIPTION
Add ATTITUDE and TIMESYNC message to custom MAVLink mode.
For use with custom AVSS parachute. The ATTITUDE messages are used as a
"fast heartbeat", and TIMESYNC is needed to synchronise the clock used in parachute logs.