### PR TITLE
vtol_att_control: check airspeed for a time period before the transition

### DIFF
--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -99,6 +99,8 @@ private:
 	float _reverse_output{0.0f};
 	float _airspeed_trans_blend_margin{0.0f};
 
+	hrt_abstime _timestamp_transition_speed_detected{0};
+
 	void parameters_update() override;
 };
 #endif


### PR DESCRIPTION
This PR provides logic to prevent early transition (MC to FW) due to airspeed measurement spikes. <

**Issue**
The airspeed value (calibrated_airspeed_m_s) that is used for comparing it with the `VT_ARSP_TRANS` parameter can have spikes that can cause to early transition to FW that can cause issues such as vehicle entering into the **under-speed state**, and other issues since the vehicle didn't develop real speed for transition to fixed-wing state. 

The image shows very high-value spikes that are happening in single samples: 
![image](https://github.com/aviant-tech/PX4-Autopilot/assets/10188706/16f9df80-dea8-4ab6-b3fa-125589c0024d)

**Solution**
The solution in this PR will check for consecutive calibrated_airspeed_m_s to be higher than the parameter `VT_ARSP_TRANS` for 250 ms. The sample rate inside the airspeed_validated module is 100ms, so this means that 3 consecutive samples will be checked before the transition is triggered. If one sample is below the parameter value, logic will reset and it will wait for other samples. 

The request was to keep transition latency under 500 ms and this is fixing it to 250 ms. 

The solution is tested inside SITL by injecting high and low calibrated_airspeed_m_s values. 
