### PR TITLE
feat: UAVCAN_FWD_MBD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 	branch = master
 [submodule "src/drivers/uavcan/libuavcan"]
 	path = src/drivers/uavcan/libuavcan
-	url = https://github.com/dronecan/libuavcan.git
+	url = https://github.com/aviant-tech/libuavcan.git
 	branch = main
 [submodule "Tools/jMAVSim"]
 	path = Tools/jMAVSim

--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -58,6 +58,7 @@ UavcanGnssBridge::UavcanGnssBridge(uavcan::INode &node) :
 	_sub_auxiliary(node),
 	_sub_fix(node),
 	_sub_fix2(node),
+	_sub_moving_baseline_data(node),
 	_pub_moving_baseline_data(node),
 	_pub_rtcm_stream(node),
 	_channel_using_fix2(new bool[_max_channels])
@@ -100,7 +101,6 @@ UavcanGnssBridge::init()
 		return res;
 	}
 
-
 	// UAVCAN_PUB_RTCM
 	int32_t uavcan_pub_rtcm = 0;
 	param_get(param_find("UAVCAN_PUB_RTCM"), &uavcan_pub_rtcm);
@@ -111,12 +111,30 @@ UavcanGnssBridge::init()
 		_rtcm_stream_pub_perf = perf_alloc(PC_INTERVAL, "uavcan: gnss: rtcm stream pub");
 	}
 
+	// UAVCAN_FWD_MBD
+	int32_t uavcan_fwd_mbd = 0;
+	param_get(param_find("UAVCAN_FWD_MBD"), &uavcan_fwd_mbd);
+
+	if (uavcan_fwd_mbd == 1) {
+		res = _sub_moving_baseline_data.start(MovingBaselineDataBinder(this, &UavcanGnssBridge::moving_baseline_sub_cb));
+
+		if (res < 0) {
+			PX4_WARN("Subscriber for MBD forwarding failed %i", res);
+			return res;
+		}
+
+		_forward_moving_baseline_data = true;
+	}
+
 	// UAVCAN_PUB_MBD
 	int32_t uavcan_pub_mbd = 0;
 	param_get(param_find("UAVCAN_PUB_MBD"), &uavcan_pub_mbd);
 
 	if (uavcan_pub_mbd == 1) {
 		_publish_moving_baseline_data = true;
+	}
+
+	if (uavcan_pub_mbd == 1 || uavcan_fwd_mbd == 1) {
 		_pub_moving_baseline_data.setPriority(uavcan::TransferPriority::NumericallyMax);
 		_moving_baseline_data_pub_perf = perf_alloc(PC_INTERVAL, "uavcan: gnss: moving baseline data rtcm stream pub");
 	}
@@ -156,6 +174,20 @@ UavcanGnssBridge::gnss_fix_sub_cb(const uavcan::ReceivedDataStructure<uavcan::eq
 	msg.velocity_covariance.unpackSquareMatrix(vel_cov);
 
 	process_fixx(msg, fix_type, pos_cov, vel_cov, valid_pos_cov, valid_vel_cov, NAN, NAN, NAN);
+}
+
+void UavcanGnssBridge::moving_baseline_sub_cb(const uavcan::ReceivedDataStructure<ardupilot::gnss::MovingBaselineData>
+		&msg)
+{
+	if (_forward_moving_baseline_data == 0) {
+		return;
+	}
+
+	// Do not broadcast on back to the originating interface.
+	uint8_t iface_mask = ~(uint8_t{1} << msg.getIfaceIndex());
+
+	_pub_moving_baseline_data.broadcast(iface_mask, uavcan::NodeID(msg.getSrcNodeID().get()), msg);
+	perf_count(_moving_baseline_data_pub_perf);
 }
 
 void

--- a/src/drivers/uavcan/sensors/gnss.hpp
+++ b/src/drivers/uavcan/sensors/gnss.hpp
@@ -81,6 +81,7 @@ private:
 	void gnss_auxiliary_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Auxiliary> &msg);
 	void gnss_fix_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix> &msg);
 	void gnss_fix2_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix2> &msg);
+	void moving_baseline_sub_cb(const uavcan::ReceivedDataStructure<ardupilot::gnss::MovingBaselineData> &msg);
 
 	template <typename FixType>
 	void process_fixx(const uavcan::ReceivedDataStructure<FixType> &msg,
@@ -110,11 +111,16 @@ private:
 		void (UavcanGnssBridge::*)(const uavcan::TimerEvent &)>
 		TimerCbBinder;
 
+	typedef uavcan::MethodBinder<UavcanGnssBridge *,
+		void (UavcanGnssBridge::*)(const uavcan::ReceivedDataStructure<ardupilot::gnss::MovingBaselineData>&)>
+		MovingBaselineDataBinder;
+
 	uavcan::INode &_node;
 
 	uavcan::Subscriber<uavcan::equipment::gnss::Auxiliary, AuxiliaryCbBinder> _sub_auxiliary;
 	uavcan::Subscriber<uavcan::equipment::gnss::Fix, FixCbBinder> _sub_fix;
 	uavcan::Subscriber<uavcan::equipment::gnss::Fix2, Fix2CbBinder> _sub_fix2;
+	uavcan::Subscriber<ardupilot::gnss::MovingBaselineData, MovingBaselineDataBinder> _sub_moving_baseline_data;
 
 	uavcan::Publisher<ardupilot::gnss::MovingBaselineData> _pub_moving_baseline_data;
 	uavcan::Publisher<uavcan::equipment::gnss::RTCMStream> _pub_rtcm_stream;
@@ -131,6 +137,7 @@ private:
 
 	bool _publish_rtcm_stream{false};
 	bool _publish_moving_baseline_data{false};
+	bool _forward_moving_baseline_data{false};
 
 	perf_counter_t _rtcm_stream_pub_perf{nullptr};
 	perf_counter_t _moving_baseline_data_pub_perf{nullptr};

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -369,6 +369,20 @@ PARAM_DEFINE_INT32(UAVCAN_SUB_RNG, 0);
 PARAM_DEFINE_INT32(UAVCAN_SUB_BTN, 0);
 
 /**
+ * forwarding of moving baseline data
+ *
+ * Subscribe to moving baseline messages on UAVCAN, and broadcast
+ * any incoming messages to all UAVCAN interfaces.
+ * This is useful for operating a GPS-for-yaw system with GPSes on
+ * different CAN buses.
+ *
+ * @boolean
+ * @reboot_required true
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_FWD_MBD, 0);
+
+/**
  * logging verbosity
  *
  * Log messages received on uavcan if they have given severity level or higher.

--- a/src/drivers/uavcannode/Subscribers/MovingBaselineData.hpp
+++ b/src/drivers/uavcannode/Subscribers/MovingBaselineData.hpp
@@ -57,7 +57,13 @@ class MovingBaselineData :
 public:
 	MovingBaselineData(uavcan::INode &node) :
 		UavcanSubscriberBase(ardupilot::gnss::MovingBaselineData::DefaultDataTypeID),
-		uavcan::Subscriber<ardupilot::gnss::MovingBaselineData, MovingBaselineDataBinder>(node)
+		uavcan::Subscriber<ardupilot::gnss::MovingBaselineData, MovingBaselineDataBinder>(node),
+		_src_id_filter{-1}
+	{}
+	MovingBaselineData(uavcan::INode &node, int32_t src_id_filter) :
+		UavcanSubscriberBase(ardupilot::gnss::MovingBaselineData::DefaultDataTypeID),
+		uavcan::Subscriber<ardupilot::gnss::MovingBaselineData, MovingBaselineDataBinder>(node),
+		_src_id_filter{src_id_filter}
 	{}
 
 	bool init()
@@ -79,8 +85,13 @@ public:
 	}
 
 private:
+	int32_t _src_id_filter;
 	void callback(const uavcan::ReceivedDataStructure<ardupilot::gnss::MovingBaselineData> &msg)
 	{
+		if (_src_id_filter != -1 && (msg.getSrcNodeID().get() != _src_id_filter)) {
+			return;
+		}
+
 		// Don't republish a message from ourselves
 		if (msg.getSrcNodeID().get() != getNode().getNodeID().get()) {
 			gps_inject_data_s gps_inject_data{};


### PR DESCRIPTION
Forward moving baseline data received via UAVCAN to all CAN buses.
This is useful for a GPS-for-yaw setup with receivers on different buses

Previously, both receivers have to be on the same UAVCAN bus when using GPS-for-yaw. We want to use receivers on different CAN buses for redundancy reasons.

This PR adds a new parameter, "UAVCAN_FWD_MBD", which when enabled, subscribes to moving baseline data messages over UAVCAN. When a message is received, it is published to all UAVCAN buses.

Currently, the message is published to all UAVCAN buses, also the one from which it was received. A custom publisher could be implemented to avoid sending it here as well.

This has been tested using a GPS-for-yaw setup with two ARK RTK GPS modules, and a Cube Orange autopilot with one receiver plugged into each CAN bus.
