### PR TITLE
logger: log viertual attitude setpoints

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -63,6 +63,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("esc_status", 250);
 	add_topic("failure_detector_status", 100);
 	add_optional_topic("follow_target", 500);
+	add_topic("fw_virtual_attitude_setpoint", 50);
 	add_optional_topic("generator_status");
 	add_optional_topic("gps_dump");
 	add_optional_topic("heater_status");
@@ -75,6 +76,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("magnetometer_bias_estimate", 200);
 	add_topic("manual_control_setpoint", 200);
 	add_topic("manual_control_switches");
+	add_topic("mc_virtual_attitude_setpoint", 50);
 	add_topic("mission_result");
 	add_topic("navigator_mission_item");
 	add_topic("npfg_status", 100);


### PR DESCRIPTION
These are used by VTOL vehicles. MC virtual attitude setpoint is relevant for tuning pusher assist, as it shows what the pitch setpoint is before the pusher assist code changes it.
