### PR TITLE
ekf2: Redefine ECL_ERR from PX4_DEBUG to PX4_INFO

### DIFF
--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -45,7 +45,7 @@
 #if defined(MODULE_NAME)
 # define ECL_INFO PX4_DEBUG
 # define ECL_WARN PX4_DEBUG
-# define ECL_ERR  PX4_DEBUG
+# define ECL_ERR  PX4_INFO
 # define ECL_DEBUG PX4_DEBUG
 #else
 # define ECL_INFO(X, ...) printf(X "\n", ##__VA_ARGS__)


### PR DESCRIPTION
Because we want to log these events in non-debug builds without alerting the pilot
This would have been extremely useful in the recent EKF troubleshooting processes