### PR TITLE
vtol_att_control: publish vtol_transition_failsafe and vtol_in_rw_mode in same update

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -271,7 +271,7 @@ VtolAttitudeControl::quadchute(QuadchuteReason reason)
 			break;
 		}
 
-		_vtol_vehicle_status.vtol_transition_failsafe = true;
+		_quadchute_requested = true;
 	}
 }
 
@@ -476,6 +476,14 @@ VtolAttitudeControl::Run()
 		// check if mc and fw sp were updated
 		bool mc_att_sp_updated = _mc_virtual_att_sp_sub.update(&_mc_virtual_att_sp);
 		bool fw_att_sp_updated = _fw_virtual_att_sp_sub.update(&_fw_virtual_att_sp);
+
+		// Set vtol_transition_failsafe flag if quadchute was requested the previous iteration
+		// We do this before _vtol_type->update_vtol_state() so that
+		// failsafe flag and mr flag is updated at the same iteration
+		if (_quadchute_requested) {
+			_vtol_vehicle_status.vtol_transition_failsafe = true;
+			_quadchute_requested = false;
+		}
 
 		// update the vtol state machine which decides which mode we are in
 		_vtol_type->update_vtol_state();

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -262,6 +262,7 @@ private:
 	VtolType	*_vtol_type{nullptr};	// base class for different vtol types
 
 	bool		_initialized{false};
+	bool		_quadchute_requested{false};
 
 	perf_counter_t	_loop_perf;			/**< loop performance counter */
 


### PR DESCRIPTION
Previously, vtol_transition_failsafe would be published in one iteration of the loop in vtol_att_control, while vtol_in_rw_mode based on vtol_transition_failsafe would be updated in the next. This could cause RTL to create a mission item for MR while the navigator still uses FW mode for calculating acceptance radius using in the RTL mission item.

Before using, we should probably test a bit more in simulator, and check other places in the code that the flags are used, to see if this can cause unintended changes as well. But should be OK for a core review.

EDIT: Have checked more in code, without finding anywhere else where this should be an issue. Tested in simulator.