### PR TITLE
Add option to ignore a range of icao addresses

### DIFF
--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -445,6 +445,8 @@ private:
 		(ParamInt<px4::params::NAV_TRAFF_AVOID>)    _param_nav_traff_avoid,	/**< avoiding other aircraft is enabled */
 		(ParamFloat<px4::params::NAV_TRAFF_A_RADU>) _param_nav_traff_a_radu,	/**< avoidance Distance Unmanned*/
 		(ParamFloat<px4::params::NAV_TRAFF_A_RADM>) _param_nav_traff_a_radm,	/**< avoidance Distance Manned*/
+		(ParamInt<px4::params::NAV_TRAFF_IGNADR>) _param_nav_traff_ignadr,  /**< ignore icao address for avoidance*/
+		(ParamInt<px4::params::NAV_TRAFF_IGNCNT>) _param_nav_traff_igncdr,  /**< number of sequential icoa addresses to ignore*/
 
 		// non-navigator parameters
 		// Mission (MIS_*)

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -155,6 +155,31 @@ PARAM_DEFINE_FLOAT(NAV_TRAFF_A_RADM, 500);
 PARAM_DEFINE_FLOAT(NAV_TRAFF_A_RADU, 10);
 
 /**
+ * Ignore this ICAO address for traffic avoidance.
+ *
+ * Also ignore subsequent addresses if NAV_TRAFF_IGNCNT is greater than 1.
+ * Not used if NAV_TRAFF_IGNCNT is 0.
+ *
+ * @min 0
+ * @max 16777215
+
+ * @group Mission
+ */
+PARAM_DEFINE_INT32(NAV_TRAFF_IGNADR, 0);
+
+/**
+ * Ignore number of ICAO addresses to ignore for traffic avoidance.
+ *
+ * Starting with NAV_TRAFF_IGNADR. Set to 0 to disable.
+ *
+ * @min 0
+ * @max 16777215
+
+ * @group Mission
+ */
+PARAM_DEFINE_INT32(NAV_TRAFF_IGNCNT, 0);
+
+/**
  * Airfield home Lat
  *
  * Latitude of airfield home waypoint


### PR DESCRIPTION
For traffic avoidance, this adds the option to give a range of icao
addresses that will not trigger the configured traffic avoidance action.
Can be used to ignore an external transponder in the vehicle, or other
vehicles in the same fleet.
