### PR TITLE
ekf2: add parameter for minimum gnss fix type required

### DIFF
--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -329,6 +329,7 @@ struct parameters {
 	float req_pdop{2.0f};			///< maximum acceptable position dilution of precision
 	float req_hdrift{0.3f};			///< maximum acceptable horizontal drift speed (m/s)
 	float req_vdrift{0.5f};			///< maximum acceptable vertical drift speed (m/s)
+	int32_t req_fixtype{3};        ///< minimum acceptable fix type
 
 	// XYZ offset of sensors in body axes (m)
 	Vector3f imu_pos_body;			///< xyz position of IMU in body frame (m)

--- a/src/modules/ekf2/EKF/gps_checks.cpp
+++ b/src/modules/ekf2/EKF/gps_checks.cpp
@@ -144,7 +144,8 @@ bool Ekf::collect_gps(const gps_message &gps)
 bool Ekf::gps_is_good(const gps_message &gps)
 {
 	// Check the fix type
-	_gps_check_fail_status.flags.fix = (gps.fix_type < 3);
+	const int32_t min_fixtype = 3;
+	_gps_check_fail_status.flags.fix = (gps.fix_type < math::max(min_fixtype, _params.req_fixtype));
 
 	// Check the number of satellites
 	_gps_check_fail_status.flags.nsats = (gps.nsats < _params.req_nsats);

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -105,6 +105,7 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_req_pdop(_params->req_pdop),
 	_param_ekf2_req_hdrift(_params->req_hdrift),
 	_param_ekf2_req_vdrift(_params->req_vdrift),
+	_param_ekf2_req_fixtype(_params->req_fixtype),
 	_param_ekf2_aid_mask(_params->fusion_mode),
 	_param_ekf2_hgt_mode(_params->vdist_sensor_type),
 	_param_ekf2_terr_mask(_params->terrain_fusion_mode),

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -407,6 +407,7 @@ private:
 		(ParamExtFloat<px4::params::EKF2_REQ_HDRIFT>)
 		_param_ekf2_req_hdrift,	///< maximum acceptable horizontal drift speed (m/s)
 		(ParamExtFloat<px4::params::EKF2_REQ_VDRIFT>) _param_ekf2_req_vdrift,	///< maximum acceptable vertical drift speed (m/s)
+		(ParamExtInt<px4::params::EKF2_REQ_FIXTYPE>) _param_ekf2_req_fixtype,   ///< minimum acceptable fix type
 
 		// measurement source control
 		(ParamExtInt<px4::params::EKF2_AID_MASK>)

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -254,6 +254,20 @@ PARAM_DEFINE_FLOAT(EKF2_REQ_HDRIFT, 0.1f);
 PARAM_DEFINE_FLOAT(EKF2_REQ_VDRIFT, 0.2f);
 
 /**
+ * Required minimum GNSS fix type.
+ *
+ * These match the MAVLink enum type GPS_FIX_TYPE.
+ *
+ * @group EKF2
+ * @value 3 3D Fix
+ * @value 4 DGNSS (code differential)
+ * @value 5 RTK float
+ * @value 6 RTK fixed/integer
+ * @reboot_required true
+ */
+PARAM_DEFINE_INT32(EKF2_REQ_FIXTYPE, 3);
+
+/**
  * Rate gyro noise for covariance prediction.
  *
  * @group EKF2


### PR DESCRIPTION
Use parameter value instead of hard coded 3 (3D fix). We do not allow
for less fix, but can require DGNSS/RTK fix in order to start using the
GNSS.

Note: we will need to redo this for dual GPS setup later
