### PR TITLE
Add support for rally point types

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -338,6 +338,7 @@ MavlinkMissionManager::send_mission_item(uint8_t sysid, uint8_t compid, uint16_t
 			mission_item.lat = mission_safe_point.lat;
 			mission_item.lon = mission_safe_point.lon;
 			mission_item.altitude = mission_safe_point.alt;
+			mission_item.params[0] = static_cast<float>(mission_safe_point.type);
 		}
 		break;
 
@@ -1173,6 +1174,13 @@ MavlinkMissionManager::handle_mission_item_both(const mavlink_message_t *msg)
 				mission_safe_point.lon = mission_item.lon;
 				mission_safe_point.alt = mission_item.altitude;
 				mission_safe_point.frame = mission_item.frame;
+				mission_safe_point.type = static_cast<uint8_t>(mission_item.params[0]);
+
+				if (mission_safe_point.type >= SAFE_POINT_TYPE_END) {
+					// Invalid type, set to default
+					mission_safe_point.type = SAFE_POINT_TYPE_NORMAL;
+				}
+
 				write_failed = dm_write(DM_KEY_SAFE_POINTS, wp.seq + 1, &mission_safe_point,
 							sizeof(mission_safe_point_s)) != sizeof(mission_safe_point_s);
 			}
@@ -1452,6 +1460,7 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 
 		case MAV_CMD_NAV_RALLY_POINT:
 			mission_item->nav_cmd = (NAV_CMD)mavlink_mission_item->command;
+			mission_item->params[0] = mavlink_mission_item->param1;
 			break;
 
 		default:
@@ -1732,6 +1741,7 @@ MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *
 			break;
 
 		case MAV_CMD_NAV_RALLY_POINT:
+			mavlink_mission_item->param1 = mission_item->params[0];
 			break;
 
 

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -128,6 +128,13 @@ enum NAV_FRAME {
 	NAV_FRAME_GLOBAL_TERRAIN_ALT_INT = 11
 };
 
+enum SAFE_POINT_TYPE {
+	SAFE_POINT_TYPE_NORMAL = 0,
+	SAFE_POINT_TYPE_MR_ONLY = 1,
+	SAFE_POINT_TYPE_FW_ONLY = 2,
+	SAFE_POINT_TYPE_END = 3  // Used to validate input
+};
+
 /**
  * @addtogroup topics
  * @{
@@ -234,8 +241,9 @@ struct mission_safe_point_s {
 	double lon;
 	float alt;
 	uint8_t frame;					/**< MAV_FRAME */
+	uint8_t type;					/**< SAFE_POINT_TYPE */
 
-	uint8_t _padding0[3];				/**< padding struct size to alignment boundary  */
+	uint8_t _padding0[2];				/**< padding struct size to alignment boundary  */
 };
 
 #if (__GNUC__ >= 5) || __clang__

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -192,6 +192,15 @@ void RTL::find_RTL_destination()
 			continue;
 		}
 
+		// Discard safe point if it does not match MR/FW type
+		if ((mission_safe_point.type == SAFE_POINT_TYPE_MR_ONLY
+		     && (_navigator->get_vstatus()->vehicle_type != vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
+			 || _navigator->get_vstatus()->in_transition_to_fw))
+		    || (mission_safe_point.type == SAFE_POINT_TYPE_FW_ONLY
+			&& _navigator->get_vstatus()->vehicle_type != vehicle_status_s::VEHICLE_TYPE_FIXED_WING)) {
+			continue;
+		}
+
 		// TODO: take altitude into account for distance measurement
 		dlat = mission_safe_point.lat - global_position.lat;
 		dlon = mission_safe_point.lon - global_position.lon;


### PR DESCRIPTION
**This PR should be test flown before merge**

Need new QGC features https://github.com/aviant-tech/qgroundcontrol/pull/25

Rally points can now be always active (default/old behavior) or setup to
only be valid for either MR or FW flight.

Uses parameter 1 in the MAVLink message
(https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_RALLY_POINT) to
set type, 0=Always, 1=MR only, 2=FW only.