### PR TITLE
workflow: releases built on tag push will be pre-release

### DIFF
--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -80,6 +80,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
+        prerelease: true
         files: |
           build/cubepilot_cubeorange_default/*.px4
           build/cubepilot_cubeorange_default/*.bin


### PR DESCRIPTION
This is normally what we want, and we will manually update it to
"latest" when it is ready for production.
