### PR TITLE
rtl: return at RTL_RETURN_ALT above destination, not home

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -245,8 +245,7 @@ void RTL::find_RTL_destination()
 		_rtl_alt = calculate_return_alt_from_cone_half_angle((float)_param_rtl_cone_half_angle_deg.get());
 
 	} else {
-		_rtl_alt = max(global_position.alt, max(_destination.alt,
-							_navigator->get_home_position()->alt + _param_rtl_return_alt.get()));
+		_rtl_alt = max(global_position.alt, _destination.alt + _param_rtl_return_alt.get());
 	}
 }
 


### PR DESCRIPTION
This is the same behavior as in 1.14 (fixed in
https://github.com/PX4/PX4-Autopilot/pull/19928), and as described in
the documentation for RTL_RETURN_ALT.
