### PR TITLE
vtol_att_control: use filtered airspeed for forward and backtransition acceptance & blending

### DIFF
--- a/msg/vtol_vehicle_status.msg
+++ b/msg/vtol_vehicle_status.msg
@@ -12,3 +12,6 @@ bool vtol_in_trans_mode
 bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW
 bool vtol_transition_failsafe		# vtol in transition failsafe mode
 bool fw_permanent_stab			# In fw mode stabilize attitude even if in manual mode
+
+float32 airspeed_filtered		# Filtered airspeed used during transition. NAN if invalid
+float32[4] mc_weights			# Multicopter blending weights for [roll, pitch, yaw, throttle]

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -99,8 +99,6 @@ private:
 	float _reverse_output{0.0f};
 	float _airspeed_trans_blend_margin{0.0f};
 
-	hrt_abstime _timestamp_transition_speed_detected{0};
-
 	void parameters_update() override;
 };
 #endif

--- a/src/modules/vtol_att_control/standard_params.c
+++ b/src/modules/vtol_att_control/standard_params.c
@@ -62,6 +62,17 @@
 PARAM_DEFINE_INT32(VT_FWD_THRUST_EN, 0);
 
 /**
+* Time constant for filtering airspeed measurements used during transition.
+*
+* @unit s
+* @decimal 1
+* @min 0.0
+* @max 5.0
+* @group VTOL Attitude Control
+*/
+PARAM_DEFINE_FLOAT(VT_ARSP_TAU, 1.0f);
+
+/**
  * Fixed-wing actuator thrust scale for hover forward flight.
  *
  * Scale applied to the demanded down-pitch to get the fixed-wing forward actuation in hover mode.

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -677,3 +677,8 @@ float VtolType::getOpenLoopFrontTransitionTime() const
 {
 	return getFrontTransitionTimeFactor() * _params->front_trans_time_openloop;
 }
+
+float VtolType::get_filtered_airspeed() const
+{
+	return _attc->get_filtered_airspeed();
+}

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -79,6 +79,7 @@ struct Params {
 	float back_trans_dec_sp;
 	bool vt_mc_on_fmu;
 	int32_t vt_forward_thrust_enable_mode;
+	float vt_arsp_tau;
 	float mpc_land_alt1;
 	float mpc_land_alt2;
 };
@@ -188,6 +189,13 @@ public:
 	 * Pusher assist in hover (pusher/pull for standard VTOL, motor tilt for tiltrotor)
 	 */
 	float pusher_assist();
+
+	/**
+	 * @brief Low pass filtered airspeed to be used during transition
+	 * @returns filtered airspeed in [m/s], or NAN if airspeed is invalid
+	 *
+	 */
+	float get_filtered_airspeed() const;
 
 	virtual void blendThrottleAfterFrontTransition(float scale) {};
 


### PR DESCRIPTION
### Solved Problem
This solves an issue where spikes in airspeed values would cause oscillations in blending weights and in turn strong throttle oscillations, impairing transition performance.

### Solution
Airspeed measurements are filtered using a 1st order IIR low-pass filter which accounts for sample rate.
The filter time constant is controlled using parameter VT_ARSP_TAU.

In addition, it acts as a more robust replacement for the existing logic to prevent airspeed spikes affecting transition acceptance.