### PR TITLE
[WIP] uavcan: publish battery status over uavcan

### DIFF
--- a/src/drivers/uavcan/sensors/battery.hpp
+++ b/src/drivers/uavcan/sensors/battery.hpp
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <uORB/Subscription.hpp>
 #include "sensor_bridge.hpp"
 #include <uORB/topics/battery_status.h>
 #include <uavcan/equipment/power/BatteryInfo.hpp>
@@ -54,6 +55,8 @@ public:
 	const char *get_name() const override { return NAME; }
 
 	int init() override;
+
+	void update() override;
 
 private:
 
@@ -73,12 +76,20 @@ private:
 
 	uavcan::Subscriber<uavcan::equipment::power::BatteryInfo, BatteryInfoCbBinder> _sub_battery;
 	uavcan::Subscriber<ardupilot::equipment::power::BatteryInfoAux, BatteryInfoAuxCbBinder> _sub_battery_aux;
+	uavcan::Publisher<uavcan::equipment::power::BatteryInfo> _pub_battery_info;
+	uavcan::Publisher<ardupilot::equipment::power::BatteryInfoAux> _pub_battery_info_aux;
+	uORB::Subscription _sub_battery_uorb{ORB_ID(battery_status)};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::BAT_LOW_THR>) _param_bat_low_thr,
 		(ParamFloat<px4::params::BAT_CRIT_THR>) _param_bat_crit_thr,
-		(ParamFloat<px4::params::BAT_EMERGEN_THR>) _param_bat_emergen_thr
+		(ParamFloat<px4::params::BAT_EMERGEN_THR>) _param_bat_emergen_thr,
+		(ParamInt<px4::params::UAVCAN_PUB_BAT>) _uavcan_pub_bat,
+		(ParamFloat<px4::params::UAVCAN_BAT_RATE>) _uavcan_bat_rate
 	)
+
+	hrt_abstime _last_uavcan_pub = 0;
+	float _max_current = 0.f;
 
 	float _discharged_mah = 0.f;
 	float _discharged_mah_loop = 0.f;

--- a/src/drivers/uavcan/sensors/sensor_bridge.cpp
+++ b/src/drivers/uavcan/sensors/sensor_bridge.cpp
@@ -76,8 +76,10 @@ void IUavcanSensorBridge::make_all(uavcan::INode &node, List<IUavcanSensorBridge
 	// battery
 	int32_t uavcan_sub_bat = 1;
 	param_get(param_find("UAVCAN_SUB_BAT"), &uavcan_sub_bat);
+	int32_t uavcan_pub_bat = 1;
+	param_get(param_find("UAVCAN_PUB_BAT"), &uavcan_pub_bat);
 
-	if (uavcan_sub_bat != 0) {
+	if (uavcan_sub_bat != 0 || uavcan_pub_bat != 0) {
 		list.add(new UavcanBatteryBridge(node));
 	}
 

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -259,6 +259,30 @@ PARAM_DEFINE_INT32(UAVCAN_SUB_BARO, 0);
 PARAM_DEFINE_INT32(UAVCAN_SUB_BAT, 0);
 
 /**
+ * publisher battery
+ *
+ * Enable publishing batteryinfo to UAVCAN.
+ *
+ * @boolean
+ * @reboot_required true
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_PUB_BAT, 0);
+
+/**
+ * UAVCAN battery max publication rate
+ *
+ * UAVCAN battery info maximum publication rate. This is an upper bound,
+ * data rate is still dependant on battery status source
+ *
+ * @min 1
+ * @max 200
+ * @group UAVCAN
+ * @unit Hz
+ */
+PARAM_DEFINE_FLOAT(UAVCAN_BAT_RATE, 10.0f);
+
+/**
  * subscription differential pressure
  *
  * Enable UAVCAN differential pressure subscription.


### PR DESCRIPTION
Makes the UavcanBatteryBridge bidirectional, so it can publish uORB -> UAVCAN in addition to the existing UAVCAN -> uORB

UAVCAN_PUB_BAT: Turns on/off publishing from uORB -> UAVCAN
UAVCAN_BAT_RATE: Max rate for publishing to UAVCAN

Our own UAVCAN broadcasts will not trigger the listener callback, so we don't have to worry about loops.