### PR TITLE
Testing GNSS-denied navigation with VO

### DIFF
--- a/msg/estimator_status.msg
+++ b/msg/estimator_status.msg
@@ -124,6 +124,12 @@ uint32 gyro_device_id
 uint32 baro_device_id
 uint32 mag_device_id
 
+# If you change these definitions, you also need to change the human-friendly textual representation in EKF2::print_status
+uint8 pos_est_mode
+uint8 POS_EST_MODE_NORMAL = 0
+uint8 POS_EST_MODE_VISION_DENIED = 1
+uint8 POS_EST_MODE_GNSS_DENIED = 2
+
 # legacy local position estimator (LPE) flags
 uint8 health_flags		# Bitmask to indicate sensor health states (vel, pos, hgt)
 uint8 timeout_flags		# Bitmask to indicate timeout flags (vel, pos, hgt)

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -386,6 +386,8 @@ struct parameters {
 	const unsigned EKFGSF_reset_delay{1000000};	///< Number of uSec of bad innovations on main filter in immediate post-takeoff phase before yaw is reset to EKF-GSF value
 	const float EKFGSF_yaw_err_max{0.262f}; 	///< Composite yaw 1-sigma uncertainty threshold used to check for convergence (rad)
 	const unsigned EKFGSF_reset_count_limit{3};	///< Maximum number of times the yaw can be reset to the EKF-GSF yaw estimator value
+
+    int32_t init_denied_w_gnss{1}; ///< Allow fusion of GNSS even in GNSS-denied EFKs while disarmed
 };
 
 struct stateSample {

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -124,7 +124,7 @@ public:
 	static bool trylock_module() { return (pthread_mutex_trylock(&ekf2_module_mutex) == 0); }
 	static void unlock_module() { pthread_mutex_unlock(&ekf2_module_mutex); }
 
-	bool multi_init(int imu, int mag);
+	bool multi_init(int imu, int mag, uint8_t pos_est_mode);
 
 	int instance() const { return _instance; }
 
@@ -132,6 +132,8 @@ private:
 
 	static constexpr uint8_t MAX_NUM_IMUS = 4;
 	static constexpr uint8_t MAX_NUM_MAGS = 4;
+
+	uint8_t _pos_est_mode = estimator_status_s::POS_EST_MODE_NORMAL;
 
 	void Run() override;
 
@@ -201,6 +203,8 @@ private:
 
 	// Used to control saving of mag declination to be used on next startup
 	bool _mag_decl_saved = false;	///< true when the magnetic declination has been saved
+
+	bool _armed{false};	///< true when vehicle is armed
 
 	// Used to check, save and use learned accel/gyro/mag biases
 	struct InFlightCalibration {
@@ -544,8 +548,12 @@ private:
 
 		// Used by EKF-GSF experimental yaw estimator
 		(ParamExtFloat<px4::params::EKF2_GSF_TAS>)
-		_param_ekf2_gsf_tas_default	///< default value of true airspeed assumed during fixed wing operation
-
+		_param_ekf2_gsf_tas_default,	///< default value of true airspeed assumed during fixed wing operation
+		//
+		// Used when testing GNSS-denied EKFs
+		(ParamExtInt<px4::params::EKF2_GD_GPS_INIT>)
+		_param_ekf2_gd_gps_init	///< (Only for GNSS-denied EKFs) Allow GPS fusion while disarmed for initialisation
 	)
 };
+
 #endif // !EKF2_HPP

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -54,6 +54,7 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_odometry.h>
+#include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/wind.h>
 
 #if CONSTRAINED_MEMORY
@@ -125,6 +126,7 @@ private:
 		uint32_t gyro_device_id{0};
 		uint32_t baro_device_id{0};
 		uint32_t mag_device_id{0};
+		uint8_t pos_est_mode{0};
 
 		hrt_abstime time_last_selected{0};
 		hrt_abstime time_last_no_warning{0};
@@ -180,6 +182,7 @@ private:
 	bool _gyro_fault_detected{false};
 	bool _accel_fault_detected{false};
 
+	uint8_t _desired_pos_est_mode{estimator_status_s::POS_EST_MODE_NORMAL};
 	uint8_t _available_instances{0};
 	uint8_t _selected_instance{INVALID_INSTANCE};
 	px4::atomic<uint8_t> _request_instance{INVALID_INSTANCE};
@@ -230,6 +233,7 @@ private:
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 	uORB::Subscription _sensors_status_imu{ORB_ID(sensors_status_imu)};
+	uORB::Subscription _status_sub{ORB_ID(vehicle_status)};
 
 	// Publications
 	uORB::Publication<estimator_selector_status_s> _estimator_selector_status_pub{ORB_ID(estimator_selector_status)};
@@ -245,7 +249,8 @@ private:
 		(ParamFloat<px4::params::EKF2_SEL_IMU_RAT>) _param_ekf2_sel_imu_angle_rate,
 		(ParamFloat<px4::params::EKF2_SEL_IMU_ANG>) _param_ekf2_sel_imu_angle,
 		(ParamFloat<px4::params::EKF2_SEL_IMU_ACC>) _param_ekf2_sel_imu_accel,
-		(ParamFloat<px4::params::EKF2_SEL_IMU_VEL>) _param_ekf2_sel_imu_velocity
+		(ParamFloat<px4::params::EKF2_SEL_IMU_VEL>) _param_ekf2_sel_imu_velocity,
+		(ParamInt<px4::params::EKF2_GNSS_DENIED>) _param_ekf2_gnss_denied
 	)
 };
 #endif // !EKF2SELECTOR_HPP

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1405,3 +1405,26 @@ PARAM_DEFINE_INT32(EKF2_SYNT_MAG_Z, 0);
  * @decimal 1
  */
 PARAM_DEFINE_FLOAT(EKF2_GSF_TAS, 15.0f);
+
+/**
+ * Multi-EKF for testing of GNSS-denied navigation
+ *
+ * If enabled, run two sets of EKFs, one using GNSS data and the other using external vision and optical flow data.
+ * Only has an effect if SENS_IMU_MODE=0.
+ * Note: Currently, the GNSS-denied EKFs are not used for flight cntrol.
+ *
+ * @group EKF2
+ * @reboot_required true
+ * @boolean
+ */
+PARAM_DEFINE_INT32(EKF2_GNSS_DENIED, 0);
+
+/**
+ * If enabled, fuse GNSS data in GNSS-denied EFKs while disarmed.
+ *
+ * Only has an effect if EKF2_GNSS_DENIED=1.
+ *
+ * @group EKF2
+ * @boolean
+ */
+PARAM_DEFINE_INT32(EKF2_GD_GPS_INIT, 1);


### PR DESCRIPTION
This PR adds the possibility to run multiple EKF instances, so that there are separate instances for GNSS-based navigation and navigation with only visual odometry. The parameter `EKF2_MULTI_VIS` enables or disables this functionality.

## Base functionality
The existing pattern used for multi-imu and multi-mag EKF is extended with another dimension for multi-vision. EKF instances configured for vision discard GNSS samples, and instances configured for GNSS discards optical flow and visual odometry samples.

An exception is made while disarmed, where the vision-based estimators will get GPS data, in order to automatically initialize position during testing. 
- [ ] TODO: For future flights completely without GPS, position (and heading, if we decide to fly without mag), is to be initialized using user set lat/lon/alt/heading parameters.

## Switching between GNSS and vision estimators
For initial testing, we don't want to fly on the vision estimators. For flights using vision estimators, the flight mode is used to determine the EKF selection. This is simple to implement, simple to override for an operator in QGC, and ensures that "emergency" modes like land and RTL use GNSS position.

## General safety concerns
- Ensure that `GPS_MULTI_MAG=1` when using `GPS_MULTI_VIS` to prevent running too many EKF instances
    - Could add this in code, but feels like it belongs on the parameter level. We generally don't expect every combination of parameters to work well.

## Safety concerns for fligts using vision estimators
- [x] Geofence
  - `GF_SOURCE_GPS` must be set to GPS instead of Global Position.
- [x] Prevent erroneous termination
   - [x] Verify that any termination failsafe don't use vision estimate
   - [x] Verify parachute altitude decision alt source