### PR TITLE
BMS driver fixes

### DIFF
--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -51,10 +51,7 @@ BATT_SMBUS::BATT_SMBUS(const I2CSPIDriverConfig &config, SMBus *interface) :
 	I2CSPIDriver(config),
 	_interface(interface)
 {
-	int32_t battsource = 1;
 	int32_t batt_device_type = static_cast<int32_t>(SMBUS_DEVICE_TYPE::UNDEFINED);
-
-	param_set(param_find("BAT1_SOURCE"), &battsource);
 	param_get(param_find("BAT1_SMBUS_MODEL"), &batt_device_type);
 
 
@@ -85,9 +82,6 @@ BATT_SMBUS::~BATT_SMBUS()
 	if (_interface != nullptr) {
 		delete _interface;
 	}
-
-	int32_t battsource = 0;
-	param_set(param_find("BAT1_SOURCE"), &battsource);
 }
 
 void BATT_SMBUS::RunImpl()

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -70,9 +70,6 @@ using namespace time_literals;
 #define BATT_CELL_VOLTAGE_THRESHOLD_RTL                 0.5f            ///< Threshold in volts to RTL if cells are imbalanced
 #define BATT_CELL_VOLTAGE_THRESHOLD_FAILED              1.5f            ///< Threshold in volts to Land if cells are imbalanced
 
-#define BATT_CURRENT_UNDERVOLTAGE_THRESHOLD             5.0f            ///< Threshold in amps to disable undervoltage protection
-#define BATT_VOLTAGE_UNDERVOLTAGE_THRESHOLD             3.4f            ///< Threshold in volts to re-enable undervoltage protection
-
 #define BATT_SMBUS_ADDR                                 0x0B            ///< Default 7 bit address I2C address. 8 bit = 0x16
 
 #define BATT_SMBUS_TEMP                                 0x08            ///< temperature register
@@ -218,11 +215,6 @@ public:
 	 * @return Returns PX4_OK on success or associated read error code on failure.
 	 */
 	int get_cell_voltages();
-
-	/**
-	 * @brief Enables or disables the cell under voltage protection emergency shut off.
-	 */
-	void set_undervoltage_protection(float average_current);
 
 	void suspend();
 


### PR DESCRIPTION
This is only intended for test flights. Note that the base branch `aviant/bms_test_flights` is flight-worthy, but not  production-grade.
If this is to be used in prod, a thorough review of the combined changes should be performed.