### PR TITLE
Increase wq:uavcan stack to 4000

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -74,7 +74,7 @@ static constexpr wq_config_t INS3{"wq:INS3", 6000, -17};
 
 static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -18};
 
-static constexpr wq_config_t uavcan{"wq:uavcan", 3624, -19};
+static constexpr wq_config_t uavcan{"wq:uavcan", 4000, -19};
 
 static constexpr wq_config_t ttyS0{"wq:ttyS0", 1632, -21};
 static constexpr wq_config_t ttyS1{"wq:ttyS1", 1632, -22};


### PR DESCRIPTION
Got low stack warnings with the new UAVCAN battery publishing feature. 4000 is chosen arbitrarily, a nice round number.