### PR TITLE
uavcan: Forward MovingBaselineData between CAN interfaces

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 	branch = master
 [submodule "src/drivers/uavcan/libuavcan"]
 	path = src/drivers/uavcan/libuavcan
-	url = https://github.com/dronecan/libuavcan.git
+	url = https://github.com/aviant-tech/libuavcan.git
 	branch = main
 [submodule "Tools/jMAVSim"]
 	path = Tools/jMAVSim

--- a/src/drivers/uavcan/sensors/gnss.hpp
+++ b/src/drivers/uavcan/sensors/gnss.hpp
@@ -81,6 +81,7 @@ private:
 	void gnss_auxiliary_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Auxiliary> &msg);
 	void gnss_fix_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix> &msg);
 	void gnss_fix2_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix2> &msg);
+	void moving_baseline_sub_cb(const uavcan::ReceivedDataStructure<ardupilot::gnss::MovingBaselineData> &msg);
 
 	template <typename FixType>
 	void process_fixx(const uavcan::ReceivedDataStructure<FixType> &msg,
@@ -110,11 +111,16 @@ private:
 		void (UavcanGnssBridge::*)(const uavcan::TimerEvent &)>
 		TimerCbBinder;
 
+	typedef uavcan::MethodBinder<UavcanGnssBridge *,
+		void (UavcanGnssBridge::*)(const uavcan::ReceivedDataStructure<ardupilot::gnss::MovingBaselineData>&)>
+		MovingBaselineDataBinder;
+
 	uavcan::INode &_node;
 
 	uavcan::Subscriber<uavcan::equipment::gnss::Auxiliary, AuxiliaryCbBinder> _sub_auxiliary;
 	uavcan::Subscriber<uavcan::equipment::gnss::Fix, FixCbBinder> _sub_fix;
 	uavcan::Subscriber<uavcan::equipment::gnss::Fix2, Fix2CbBinder> _sub_fix2;
+	uavcan::Subscriber<ardupilot::gnss::MovingBaselineData, MovingBaselineDataBinder> _sub_moving_baseline_data;
 
 	uavcan::Publisher<ardupilot::gnss::MovingBaselineData> _pub_moving_baseline_data;
 	uavcan::Publisher<uavcan::equipment::gnss::RTCMStream> _pub_rtcm_stream;
@@ -131,6 +137,7 @@ private:
 
 	bool _publish_rtcm_stream{false};
 	bool _publish_moving_baseline_data{false};
+	bool _forward_moving_baseline_data{false};
 
 	perf_counter_t _rtcm_stream_pub_perf{nullptr};
 	perf_counter_t _moving_baseline_data_pub_perf{nullptr};

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -369,6 +369,20 @@ PARAM_DEFINE_INT32(UAVCAN_SUB_RNG, 0);
 PARAM_DEFINE_INT32(UAVCAN_SUB_BTN, 0);
 
 /**
+ * forwarding of moving baseline data
+ *
+ * Subscribe to moving baseline messages on UAVCAN, and broadcast
+ * any incoming messages to all UAVCAN interfaces.
+ * This is useful for operating a GPS-for-yaw system with GPSes on
+ * different CAN buses.
+ *
+ * @boolean
+ * @reboot_required true
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_FWD_MBD, 0);
+
+/**
  * logging verbosity
  *
  * Log messages received on uavcan if they have given severity level or higher.

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
@@ -488,6 +488,21 @@ sensor_gps_s GpsBlending::gps_blend_states(float blend_weights[GPS_MAX_RECEIVERS
 	gps_blended_state.heading = _gps_state[gps_best_yaw_index].heading;
 	gps_blended_state.heading_offset = _gps_state[gps_best_yaw_index].heading_offset;
 
+	// Blend UTC timestamp from all receivers that are publishing a valid time_utc_usec value
+	double utc_weight_sum = 0.0;
+	double utc_time_sum = 0.0;
+
+	for (uint8_t i = 0; i < GPS_MAX_RECEIVERS_BLEND; i++) {
+		if (_gps_state[i].time_utc_usec > 0) {
+			utc_time_sum += (double)_gps_state[i].time_utc_usec * (double)blend_weights[i];
+			utc_weight_sum += (double)blend_weights[i];
+		}
+	}
+
+	if (utc_weight_sum > 0.0) {
+		gps_blended_state.time_utc_usec = (uint64_t)(utc_time_sum / utc_weight_sum);
+	}
+
 	return gps_blended_state;
 }
 

--- a/src/modules/sensors/vehicle_gps_position/gps_blending_test.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending_test.cpp
@@ -270,3 +270,31 @@ TEST_F(GpsBlendingTest, dualReceiverFailover)
 	EXPECT_EQ(gps_blending.getSelectedGps(), 0);
 	EXPECT_TRUE(gps_blending.isNewOutputDataAvailable());
 }
+
+TEST_F(GpsBlendingTest, dualReceiverUTCTime)
+{
+	GpsBlending gps_blending;
+	sensor_gps_s gps_data0 = getDefaultGpsData();
+	sensor_gps_s gps_data1 = getDefaultGpsData();
+
+	// WHEN: Only GPS1 has a nonzero UTC time
+	gps_blending = GpsBlending();
+	gps_data1.time_utc_usec = 1700000000000000ULL;
+	gps_blending.setGpsData(gps_data0, 0);
+	gps_blending.setGpsData(gps_data1, 1);
+	gps_blending.setBlendingUseHPosAccuracy(true);
+	gps_blending.update(_time_now_us);
+	// THEN: GPS 1 time should be used
+	EXPECT_EQ(gps_blending.getOutputGpsData().time_utc_usec, gps_data1.time_utc_usec);
+
+	// WHEN: Both GPSes have a nonzero UTC time
+	gps_blending = GpsBlending();
+	gps_data0.time_utc_usec = 1700000000001000ULL;
+	gps_data1.time_utc_usec = 1700000000000000ULL;
+	gps_blending.setGpsData(gps_data0, 0);
+	gps_blending.setGpsData(gps_data1, 1);
+	gps_blending.setBlendingUseHPosAccuracy(true);
+	gps_blending.update(_time_now_us);
+	// THEN: The average of the two timestamps should be used
+	EXPECT_EQ(gps_blending.getOutputGpsData().time_utc_usec, 1700000000000500ULL);
+}


### PR DESCRIPTION
For differential yaw to work, MovingBaselineData must be sent from the moving base GPS to the rover gps. This currently happens automatically if they are on the same CAN bus. However, for redundancy, we want the GPSes on different buses.

This PR adds the possibility for forwarding MovingBaselineData from one CAN bus to another. The original sender's node ID is preserved, and the message is only forwarded to the other can interfaces - not the one where it arrived. In order to do this, updates to libuavcan were required. Therefore, the original submodule pointer is replaced with our fork.

Forwarding of MBD is controlled with the new parameter UAVCAN_FWD_MBD.

In addition, this PR adresses a bug where the time_utc_usec field isn't populated when blending multiple GPSes. This fix has already been accepted into the upstream PX4.

We have already done lots of flights with dual-gps drones, NX01, NX02 and, NX04, using this code.