### PR TITLE
mc_pos_control: Low-pass filter velocity measurements

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -175,6 +175,10 @@ private:
 		(ParamFloat<px4::params::MPC_Z_VEL_ALL>)    _param_mpc_z_vel_all
 	);
 
+	control::BlockLowPass _vel_x_filtered;
+	control::BlockLowPass _vel_y_filtered;
+	control::BlockLowPass _vel_z_filtered;
+
 	control::BlockDerivative _vel_x_deriv; /**< velocity derivative in x */
 	control::BlockDerivative _vel_y_deriv; /**< velocity derivative in y */
 	control::BlockDerivative _vel_z_deriv; /**< velocity derivative in z */

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -518,6 +518,19 @@ PARAM_DEFINE_FLOAT(MPC_HOLD_MAX_XY, 0.8f);
 PARAM_DEFINE_FLOAT(MPC_HOLD_MAX_Z, 0.6f);
 
 /**
+ * Low pass filter cut freq. for velocity measurements used in multicopter position control
+ *
+ * A low cut off frequency means that there will be a more low-pass filtering
+ * If the frequency is set higher than 999 Hz, the filter will be disabled.
+ *
+ * @unit Hz
+ * @min 0.5
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_VEL_LP, 1000.0f);
+
+/**
  * Low pass filter cut freq. for numerical velocity derivative
  *
  * @unit Hz


### PR DESCRIPTION
Introduce a low-pass filter for velocity measurements used by the multicopter velocity controller.

We have problems with oscillations on the drone that likely stem from the velocity controller giving out acceleration setpoints that have a bandwidth that is higher than what the drone dynamics and attitude controller can handle.

By limiting the bandwidth of velocity controller input signal, the output bandwidth wil also be limited. This works in a similay way to how the D term is band limited already. A new parameter, MPC_VEL_LP, controls this functionality.

**Why the seemingly "hacky" behaviour of disabling the filter by setting it to a high value?**
The `control::BlockLowPass` which is used for the filtering, takes in a cutoff frequency, and due to the way `control::Block` deals with parameters, it is not trivial to change this. Sine a low cutoff frequency implies a lot of filtering, it is dangerous to have the default as 0. A user cold then think to modify it just "slightly" would not change behaviour, when in fact, changing it from 0 to 0.1 would have a huge effect, blocking nearly all frequencies. Also, if the default is 0, we cannot define a suitable minimum for the parameter, as the default value would be below the minimum

**Why bypass the filter completely if setting it to a high value means that it has minimal effect?**
This is to prevent EKF checks from failing. Disabling the parameter shouldn't have minimal effect, it should have no effect.