### PR TITLE
Enable GNSS-denied flight with fallback in case of failsafe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.pyc
 *~
 .*.swp
+.cache
 .context
 .cproject
 .DS_Store

--- a/msg/estimator_selector_status.msg
+++ b/msg/estimator_selector_status.msg
@@ -20,3 +20,5 @@ float32[4] accumulated_gyro_error
 float32[4] accumulated_accel_error
 bool gyro_fault_detected
 bool accel_fault_detected
+bool gnss_denied_instance_selected
+bool latched_gnss_enabled

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -42,6 +42,7 @@
 #ifndef STATE_MACHINE_HELPER_H_
 #define STATE_MACHINE_HELPER_H_
 
+#include "uORB/topics/estimator_selector_status.h"
 #include <drivers/drv_hrt.h>
 
 #include <uORB/uORB.h>
@@ -120,14 +121,16 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		   const quadchute_actions_t quadchute_act,
 		   const offboard_loss_rc_actions_t offb_loss_rc_act,
 		   const position_nav_loss_actions_t posctl_nav_loss_act,
-		   const float param_com_rcl_act_t, const int param_com_rcl_except);
+		   const float param_com_rcl_act_t, const int param_com_rcl_except,
+		   const estimator_selector_status_s &estimator_selector_status);
 
 /*
  * Checks the validty of position data against the requirements of the current navigation
  * mode and switches mode if position data required is not available.
  */
 bool check_invalid_pos_nav_state(vehicle_status_s &status, bool old_failsafe, orb_advert_t *mavlink_log_pub,
-				 const vehicle_status_flags_s &status_flags, const bool use_rc, const bool using_global_pos);
+				 const vehicle_status_flags_s &status_flags, const bool use_rc, const bool using_global_pos,
+				 const estimator_selector_status_s &estimator_selector_status);
 
 
 // COM_LOW_BAT_ACT parameter values

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -231,6 +231,8 @@ private:
 	uint8_t _global_position_instance_prev{INVALID_INSTANCE};
 	uint8_t _odometry_instance_prev{INVALID_INSTANCE};
 
+	bool _latch_use_gnss{false};
+
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 	uORB::Subscription _sensors_status_imu{ORB_ID(sensors_status_imu)};
 	uORB::Subscription _status_sub{ORB_ID(vehicle_status)};
@@ -250,7 +252,8 @@ private:
 		(ParamFloat<px4::params::EKF2_SEL_IMU_ANG>) _param_ekf2_sel_imu_angle,
 		(ParamFloat<px4::params::EKF2_SEL_IMU_ACC>) _param_ekf2_sel_imu_accel,
 		(ParamFloat<px4::params::EKF2_SEL_IMU_VEL>) _param_ekf2_sel_imu_velocity,
-		(ParamInt<px4::params::EKF2_GNSS_DENIED>) _param_ekf2_gnss_denied
+		(ParamInt<px4::params::EKF2_GNSS_DENIED>) _param_ekf2_gnss_denied,
+		(ParamInt<px4::params::EKF2_SEL_GNSSDEN>) _param_ekf2_sel_gnss_denied
 	)
 };
 #endif // !EKF2SELECTOR_HPP

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1411,7 +1411,6 @@ PARAM_DEFINE_FLOAT(EKF2_GSF_TAS, 15.0f);
  *
  * If enabled, run two sets of EKFs, one using GNSS data and the other using external vision and optical flow data.
  * Only has an effect if SENS_IMU_MODE=0.
- * Note: Currently, the GNSS-denied EKFs are not used for flight cntrol.
  *
  * @group EKF2
  * @reboot_required true

--- a/src/modules/ekf2/ekf2_params_selector.c
+++ b/src/modules/ekf2/ekf2_params_selector.c
@@ -79,3 +79,15 @@ PARAM_DEFINE_FLOAT(EKF2_SEL_IMU_ACC, 1.0f);
  * @unit m/s
  */
 PARAM_DEFINE_FLOAT(EKF2_SEL_IMU_VEL, 2.0f);
+
+/**
+ * Whether to select GNSS-denied EKF2 instances or not
+ *
+ * If set to 1, the EKF2 selector will select GNSS-denied EKF2 instances.
+ * Else, GNSS-denied EKF2 instances will never be selected.
+ * Only has an effect if EKF2_GNSS_DENIED is set to 1.
+ *
+ * @group EKF2
+ * @boolean
+ */
+PARAM_DEFINE_INT32(EKF2_SEL_GNSSDEN, 0);


### PR DESCRIPTION
This enables selection of GNSS-denied EKF instances, depending on the parameter EKF2_SEL_GNSSDEN. Will fly GNSS-denied in MISSION or OFFBOARD flight modes. The functionality has been tested in sim using failure injection.

If any failsafe triggers, we will latch as GNSS-enabled until reboot.

Also, the termination action is disabled for position loss failsafes while a GNSS-denied EKF instance is selected, with a 1 second grace period. This is necessary to avoid unnecessary parachute landings. I don't like passing estimator_selector_status through `set_nav_state` to `check_invalid_pos_nav_state` for this feature, but I think it's good enough for our current use case.