### PR TITLE
mc_pos_control: different LPF cutoffs for XY and Z

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -46,9 +46,9 @@ MulticopterPositionControl::MulticopterPositionControl(bool vtol) :
 	ModuleParams(nullptr),
 	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers),
 	_vehicle_attitude_setpoint_pub(vtol ? ORB_ID(mc_virtual_attitude_setpoint) : ORB_ID(vehicle_attitude_setpoint)),
-	_vel_x_filtered(this, "VEL_LP"),
-	_vel_y_filtered(this, "VEL_LP"),
-	_vel_z_filtered(this, "VEL_LP"),
+	_vel_x_filtered(this, "XY_VEL_LP"),
+	_vel_y_filtered(this, "XY_VEL_LP"),
+	_vel_z_filtered(this, "Z_VEL_LP"),
 	_vel_x_deriv(this, "VELD"),
 	_vel_y_deriv(this, "VELD"),
 	_vel_z_deriv(this, "VELD")

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -518,7 +518,7 @@ PARAM_DEFINE_FLOAT(MPC_HOLD_MAX_XY, 0.8f);
 PARAM_DEFINE_FLOAT(MPC_HOLD_MAX_Z, 0.6f);
 
 /**
- * Low pass filter cut freq. for velocity measurements used in multicopter position control
+ * Low pass filter cut freq. for XY velocity measurements used in multicopter position control
  *
  * A low cut off frequency means that there will be a more low-pass filtering
  * If the frequency is set higher than 999 Hz, the filter will be disabled.
@@ -528,7 +528,20 @@ PARAM_DEFINE_FLOAT(MPC_HOLD_MAX_Z, 0.6f);
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_VEL_LP, 1000.0f);
+PARAM_DEFINE_FLOAT(MPC_XY_VEL_LP, 1000.0f);
+
+/**
+ * Low pass filter cut freq. for Z velocity measurements used in multicopter position control
+ *
+ * A low cut off frequency means that there will be a more low-pass filtering
+ * If the frequency is set higher than 999 Hz, the filter will be disabled.
+ *
+ * @unit Hz
+ * @min 0.5
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_Z_VEL_LP, 1000.0f);
 
 /**
  * Low pass filter cut freq. for numerical velocity derivative


### PR DESCRIPTION
We want to be able to have different LPF cutoffs for XY velocity and Z velocity, so we can tune XY tracking without affecting descend speed.