### PR TITLE
Fake origin for GNSS-denied EKF2 instances

### DIFF
--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -387,7 +387,11 @@ struct parameters {
 	const float EKFGSF_yaw_err_max{0.262f}; 	///< Composite yaw 1-sigma uncertainty threshold used to check for convergence (rad)
 	const unsigned EKFGSF_reset_count_limit{3};	///< Maximum number of times the yaw can be reset to the EKF-GSF yaw estimator value
 
-    int32_t init_denied_w_gnss{1}; ///< Allow fusion of GNSS even in GNSS-denied EFKs while disarmed
+    int32_t gnss_denied_init_type{0}; ///< GNSS denied initialization type (see parameter definition for details)
+
+    float gnss_denied_origin_lat{0.0f}; ///< Latitude of the origin used for GNSS denied initialization (deg)
+    float gnss_denied_origin_lon{0.0f}; ///< Longitude of the origin used for GNSS denied initialization (deg)
+    float gnss_denied_origin_alt{0.0f}; ///< Altitude of the origin used for GNSS denied initialization (m)
 };
 
 struct stateSample {

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -336,6 +336,8 @@ public:
 
 	const BaroBiasEstimator::status &getBaroBiasEstimatorStatus() const { return _baro_b_est.getStatus(); }
 
+    bool get_filter_initialised() const { return _filter_initialised; }
+
 private:
 
 	// set the internal states and status to their default value

--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -129,7 +129,7 @@ void EstimatorInterface::setMagData(const magSample &mag_sample)
 	}
 }
 
-void EstimatorInterface::setGpsData(const gps_message &gps)
+void EstimatorInterface::setGpsData(const gps_message &gps, const bool silent)
 {
 	if (!_initialised) {
 		return;
@@ -184,7 +184,9 @@ void EstimatorInterface::setGpsData(const gps_message &gps)
 
 		_gps_buffer->push(gps_sample_new);
 	} else {
-		ECL_ERR("GPS data too fast %" PRIu64, gps.time_usec - _time_last_gps);
+        if (!silent) {
+		    ECL_ERR("GPS data too fast %" PRIu64, gps.time_usec - _time_last_gps);
+        }
 	}
 }
 

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -84,7 +84,7 @@ public:
 
 	void setMagData(const magSample &mag_sample);
 
-	void setGpsData(const gps_message &gps);
+	void setGpsData(const gps_message &gps, const bool silent = false);
 
 	void setBaroData(const baroSample &baro_sample);
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1796,7 +1796,8 @@ void EKF2::FakeGpsSample(ekf2_timestamps_s &ekf2_timestamps)
 		.nsats = 14,
 		.pdop = 1.594f
 	};
-	_ekf.setGpsData(gps_msg);
+
+	_ekf.setGpsData(gps_msg, true);
 
 	_gps_time_usec = gps_msg.time_usec;
 	_gps_alttitude_ellipsoid = gps_msg.alt;

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -161,6 +161,7 @@ private:
 	void UpdateBaroSample(ekf2_timestamps_s &ekf2_timestamps);
 	bool UpdateExtVisionSample(ekf2_timestamps_s &ekf2_timestamps, vehicle_odometry_s &ev_odom);
 	bool UpdateFlowSample(ekf2_timestamps_s &ekf2_timestamps);
+	void FakeGpsSample(ekf2_timestamps_s &ekf2_timestamps);
 	void UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps);
 	void UpdateMagSample(ekf2_timestamps_s &ekf2_timestamps);
 	void UpdateRangeSample(ekf2_timestamps_s &ekf2_timestamps);
@@ -551,8 +552,11 @@ private:
 		_param_ekf2_gsf_tas_default,	///< default value of true airspeed assumed during fixed wing operation
 		//
 		// Used when testing GNSS-denied EKFs
-		(ParamExtInt<px4::params::EKF2_GD_GPS_INIT>)
-		_param_ekf2_gd_gps_init	///< (Only for GNSS-denied EKFs) Allow GPS fusion while disarmed for initialisation
+		(ParamExtInt<px4::params::EKF2_GD_INIT>)
+		_param_ekf2_gd_init,	///< (Only for GNSS-denied EKFs) Allow GPS fusion while disarmed for initialisation
+		(ParamExtFloat<px4::params::EKF2_GD_LAT>) _param_ekf2_gd_lat, ///< GNSS-denied init latitude
+		(ParamExtFloat<px4::params::EKF2_GD_LON>) _param_ekf2_gd_lon, ///< GNSS-denied init longitude
+		(ParamExtFloat<px4::params::EKF2_GD_ALT>) _param_ekf2_gd_alt ///< GNSS-denied init altitude
 	)
 };
 

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -65,6 +65,14 @@
 
 using namespace time_literals;
 
+// Matches EKF2_SEL_GNSSDEN
+enum class gnss_denied_selection_t {
+	NEVER = 0,
+	OFFBOARD = 1,
+	OFFBOARD_OR_DISARMED = 2,
+	ALWAYS = 3
+};
+
 class EKF2Selector : public ModuleParams, public px4::ScheduledWorkItem
 {
 public:
@@ -231,6 +239,9 @@ private:
 	uint8_t _global_position_instance_prev{INVALID_INSTANCE};
 	uint8_t _odometry_instance_prev{INVALID_INSTANCE};
 
+	bool _is_armed{false};
+	bool _is_offboard{false};
+	bool _is_failsafe{false};
 	bool _latch_use_gnss{false};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1419,11 +1419,54 @@ PARAM_DEFINE_FLOAT(EKF2_GSF_TAS, 15.0f);
 PARAM_DEFINE_INT32(EKF2_GNSS_DENIED, 0);
 
 /**
- * If enabled, fuse GNSS data in GNSS-denied EFKs while disarmed.
+ * How to initialize the GNSS-denied navigation origin
  *
  * Only has an effect if EKF2_GNSS_DENIED=1.
  *
  * @group EKF2
- * @boolean
+ * @value 0 No origin
+ * @value 1 GPS measurements
+ * @value 2 Fake origin (parameters EKF2_GD_LAT, EKF2_GD_LON, EKF2_GD_ALT)
+ * @decimal 0
  */
-PARAM_DEFINE_INT32(EKF2_GD_GPS_INIT, 1);
+PARAM_DEFINE_INT32(EKF2_GD_INIT, 1);
+
+/**
+ * Latitude of the origin for GNSS-denied navigation
+ *
+ * Only has an effect if EKF2_GD_INIT=2
+ *
+ * @group EKF2
+ * @unit deg
+ * @decimal 6
+ * @reboot_required true
+ * @min -90.0
+ * @max 90.0
+ */
+PARAM_DEFINE_FLOAT(EKF2_GD_LAT, 47.398039);
+
+/**
+ * Longitude of the origin for GNSS-denied navigation
+ *
+ * Only has an effect if EKF2_GD_INIT=2
+ *
+ * @group EKF2
+ * @unit deg
+ * @decimal 6
+ * @reboot_required true
+ * @min -90.0
+ * @max 90.0
+ */
+PARAM_DEFINE_FLOAT(EKF2_GD_LON, 8.545572);
+
+/**
+ * Altitude of the origin for GNSS-denied navigation
+ *
+ * Only has an effect if EKF2_GD_INIT=2
+ *
+ * @group EKF2
+ * @unit m
+ * @decimal 1
+ * @reboot_required true
+ */
+PARAM_DEFINE_FLOAT(EKF2_GD_ALT, 1.0);

--- a/src/modules/ekf2/ekf2_params_selector.c
+++ b/src/modules/ekf2/ekf2_params_selector.c
@@ -81,13 +81,15 @@ PARAM_DEFINE_FLOAT(EKF2_SEL_IMU_ACC, 1.0f);
 PARAM_DEFINE_FLOAT(EKF2_SEL_IMU_VEL, 2.0f);
 
 /**
- * Whether to select GNSS-denied EKF2 instances or not
+ * When to select GNSS-denied EKF2 instances.
  *
- * If set to 1, the EKF2 selector will select GNSS-denied EKF2 instances.
- * Else, GNSS-denied EKF2 instances will never be selected.
  * Only has an effect if EKF2_GNSS_DENIED is set to 1.
  *
  * @group EKF2
- * @boolean
+ * @value 0 Never
+ * @value 1 OFFBOARD mode
+ * @value 2 OFFBOARD or DISARMED
+ * @value 3 Always
+ *
  */
 PARAM_DEFINE_INT32(EKF2_SEL_GNSSDEN, 0);


### PR DESCRIPTION
Alternative to https://github.com/aviant-tech/PX4-Autopilot/pull/70 for true GNSS-denied flight, inspired by LPE_FAKE_ORIGIN

The main advantage of this approach is that it only affects the explicitly GNSS-denied EKF instances, so it can be tested with GPS fallback.