### PR TITLE
flight_mode_manager, orbit: increase max speed to 20 m/s

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
@@ -71,7 +71,7 @@ private:
 	/* TODO: Should be controlled by params */
 	static constexpr float _radius_min = 1.f;
 	static constexpr float _radius_max = 1e3f;
-	static constexpr float _velocity_max = 10.f;
+	static constexpr float _velocity_max = 20.f;
 	static constexpr float _acceleration_max = 2.f;
 	static constexpr float _horizontal_acceptance_radius = 2.f;
 


### PR DESCRIPTION
When using orbit to fly simulated wind, we are limited by the max speed, which is hard-coded to 10 m/s. In very low wind, we want to fly faster.