### PR TITLE
Add Aviant high rate log mode

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -261,6 +261,16 @@ void LoggedTopics::add_high_rate_topics()
 	add_topic("vehicle_rates_setpoint");
 }
 
+void LoggedTopics::add_aviant_high_rate_topics()
+{
+	add_topic("actuator_controls_0");
+	add_topic("actuator_outputs");
+	add_topic("sensor_combined");
+	add_topic("sensor_accel", 0, 2);
+	add_topic("sensor_gyro", 0, 2);
+	add_topic("vehicle_attitude");
+}
+
 void LoggedTopics::add_debug_topics()
 {
 	add_topic("debug_array");
@@ -552,5 +562,9 @@ void LoggedTopics::initialize_configured_topics(SDLogProfileMask profile)
 
 	if (profile & SDLogProfileMask::MAVLINK_TUNNEL) {
 		add_mavlink_tunnel();
+	}
+
+	if (profile & SDLogProfileMask::AVIANT_HIGH_RATE) {
+		add_aviant_high_rate_topics();
 	}
 }

--- a/src/modules/logger/logged_topics.h
+++ b/src/modules/logger/logged_topics.h
@@ -54,7 +54,8 @@ enum class SDLogProfileMask : int32_t {
 	VISION_AND_AVOIDANCE =  1 << 7,
 	RAW_IMU_GYRO_FIFO =     1 << 8,
 	RAW_IMU_ACCEL_FIFO =    1 << 9,
-	MAVLINK_TUNNEL =        1 << 10
+	MAVLINK_TUNNEL =        1 << 10,
+	AVIANT_HIGH_RATE =      1 << 11
 };
 
 enum class MissionLogType : int32_t {
@@ -169,6 +170,7 @@ private:
 	void add_thermal_calibration_topics();
 	void add_system_identification_topics();
 	void add_high_rate_topics();
+	void add_aviant_high_rate_topics();
 	void add_debug_topics();
 	void add_sensor_comparison_topics();
 	void add_vision_and_avoidance_topics();

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -126,9 +126,10 @@ PARAM_DEFINE_INT32(SDLOG_MISSION, 0);
  * 8 : Raw FIFO high-rate IMU (Gyro)
  * 9 : Raw FIFO high-rate IMU (Accel)
  * 10: Logging of mavlink tunnel message (useful for payload communication debugging)
+ * 11: Aviant-flavor high rate logs
  *
  * @min 0
- * @max 2047
+ * @max 4095
  * @bit 0 Default set (general log analysis)
  * @bit 1 Estimator replay (EKF2)
  * @bit 2 Thermal calibration
@@ -140,6 +141,7 @@ PARAM_DEFINE_INT32(SDLOG_MISSION, 0);
  * @bit 8 Raw FIFO high-rate IMU (Gyro)
  * @bit 9 Raw FIFO high-rate IMU (Accel)
  * @bit 10 Mavlink tunnel message logging
+ * @bit 11 Aviant-flavor high rate log
  * @reboot_required true
  * @group SD Logging
  */


### PR DESCRIPTION
This adds high rate (400Hz) logging for the undampened IMU, but also
removes some topics compared to the stock high rate log mode to keep the
total log amount and used CPU and bandwidth manageable.

Before merge
- [x] Ground test
- [x] Flight test
- [x] Evaluate if resulting logs are useful

We should also setup parameter monitoring to track `SDLOG_PROFILE` when released.